### PR TITLE
zh-CN Localization

### DIFF
--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -1,0 +1,64 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!--  
+    HowLongToBeatSettingsView
+    -->
+
+    <sys:String x:Key="LOCHowLongToBeatAddTagDescription">加上“主线”或者“单人”标签。</sys:String>
+
+    <sys:String x:Key="LOCHowLongToBeatIntegration">界面集成</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatIntegrationButton">添加按钮</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatIntegrationInDescription">集成到游戏描述</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatIntegrationShowTitle">显示标题</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatIntegrationTopGameDetails">在其他描述之上</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatIntegrationInCustomTheme">自定义主题集成（如被集成）</sys:String>
+
+    <!--  
+    HowLongToBeatSelect
+    -->
+
+    <sys:String x:Key="LOCHowLongToBeatSelection">通关时长How long to beat 选择</sys:String>
+    
+    <sys:String x:Key="LOCHowLongToBeatMainStory">主线</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatMainExtra">主线+支线</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatCompletionist">全达成</sys:String>
+
+    <sys:String x:Key="LOCHowLongToBeatSolo">单人</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatCoOp">合作</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatVs">竞技</sys:String>
+    
+    <sys:String x:Key="LOCHowLongToBeatPlaytime">游戏时长</sys:String>
+
+    <sys:String x:Key="LOCHowLongToBeatSearch">搜索</sys:String>
+
+    <sys:String x:Key="LOCHowLongToBeatSelect">选择</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatCancel">取消</sys:String>
+
+    <!--  
+    HowLongToBeat
+    -->
+
+    <sys:String x:Key="LOCHowLongToBeatProgression">进度</sys:String>
+
+    <sys:String x:Key="LOCHowLongToBeat1to5">1到5小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat5to10">5到10小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat10to20">10到20小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat20to30">20到30小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat30to40">30到40小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat40to50">40到50小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat50to60">50到60小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat60to70">60到70小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat70to80">70到80小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat80to90">80到90小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat90to100">90到100小时</sys:String>
+    <sys:String x:Key="LOCHowLongToBeat100plus">超过100小时</sys:String>
+
+    <!--  
+    MainView
+    -->
+
+    <sys:String x:Key="LOCHowLongToBeatTitle">通关时长How long to beat</sys:String>
+    
+</ResourceDictionary>


### PR DESCRIPTION
添加简体中文，“通关时长”作为“How long to beat”的暂时翻译
Add Simplified Chinese. "通关时长" is a temporary translation of "How long to beat".