### PR TITLE
Support manual SetCurrentPlayTime for multiple games

### DIFF
--- a/source/HowLongToBeat.cs
+++ b/source/HowLongToBeat.cs
@@ -234,11 +234,18 @@ namespace HowLongToBeat
                             $"HowLongToBeat - {resources.GetString("LOCCommonProcessing")}",
                             false
                         );
-                        globalProgressOptions.IsIndeterminate = true;
+
+                        globalProgressOptions.IsIndeterminate = args.Games.Count == 1;
 
                         PlayniteApi.Dialogs.ActivateGlobalProgress((activateGlobalProgress) =>
                         {
-                            PluginDatabase.SetCurrentPlayTime(GameMenu, 0);
+                            activateGlobalProgress.ProgressMaxValue = args.Games.Count;
+                            activateGlobalProgress.CurrentProgressValue = -1;
+                            foreach (Game game in args.Games)
+                            {
+                                activateGlobalProgress.CurrentProgressValue += 1;
+                                PluginDatabase.SetCurrentPlayTime(game, 0);
+                            }
                         }, globalProgressOptions);
                     }
                 });


### PR DESCRIPTION
When selecting multiple games, allow the right click "Set your current playtime" to update all of them.

Update the ActivateGlobalProgress progress bar for each game. Only set `IsIndeterminate` if only one game is updated.