### PR TITLE
#155 Adding a new HLTB tag if there is no data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "source/playnite-plugincommon"]
 	path = source/playnite-plugincommon
-	url = https://github.com/Lacro59/playnite-plugincommon.git
+	url = https://github.com/Jhanlon95/playnite-plugincommon.git
+	branch = master

--- a/source/HowLongToBeat.csproj
+++ b/source/HowLongToBeat.csproj
@@ -125,7 +125,8 @@
     <Compile Include="Models\HltbDataUser.cs" />
     <Compile Include="Models\HltbPostData.cs" />
     <Compile Include="Models\HltbStorefront.cs" />
-    <Compile Include="Models\HltbUserGameList.cs" />
+    <Compile Include="Models\HltbUserGamesList.cs" />
+    <Compile Include="Models\HltbUserStatsGamesList.cs" />
     <Compile Include="Models\HltbUserStats.cs" />
     <Compile Include="Models\QuickSearchItemSource.cs" />
     <Compile Include="playnite-plugincommon\CommonPluginsControls\Controls\ComboBoxRemovable.xaml.cs">

--- a/source/HowLongToBeat.csproj
+++ b/source/HowLongToBeat.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Models\HltbDataUser.cs" />
     <Compile Include="Models\HltbPostData.cs" />
     <Compile Include="Models\HltbStorefront.cs" />
+    <Compile Include="Models\HltbUserGameList.cs" />
     <Compile Include="Models\HltbUserStats.cs" />
     <Compile Include="Models\QuickSearchItemSource.cs" />
     <Compile Include="playnite-plugincommon\CommonPluginsControls\Controls\ComboBoxRemovable.xaml.cs">
@@ -168,9 +169,9 @@
     <Compile Include="playnite-plugincommon\CommonPluginsControls\PlayniteControls\SearchBox.xaml.cs">
       <DependentUpon>SearchBox.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Services\HowLongToBeatSearchData.cs" />
+    <Compile Include="Models\HltbSearchData.cs" />
     <Compile Include="Services\HowLongToBeatDatabase.cs" />
-    <Compile Include="Services\HowLongToBeatSearchRoot.cs" />
+    <Compile Include="Models\HltbSearchRoot.cs" />
     <Compile Include="Services\OldToNew.cs" />
     <Compile Include="Views\HowLongToBeatSelect.xaml.cs">
       <DependentUpon>HowLongToBeatSelect.xaml</DependentUpon>

--- a/source/HowLongToBeat.csproj
+++ b/source/HowLongToBeat.csproj
@@ -65,9 +65,11 @@
     <Reference Include="LiveCharts.Wpf, Version=0.9.7.0, Culture=neutral, PublicKeyToken=0bc1f845d1ebb8df, processorArchitecture=MSIL">
       <HintPath>packages\LiveCharts.Wpf.0.9.7\lib\net45\LiveCharts.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\PlayniteSDK.6.2.2\lib\net462\Playnite.SDK.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Playnite.SDK, Version=6.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.3.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -166,7 +168,9 @@
     <Compile Include="playnite-plugincommon\CommonPluginsControls\PlayniteControls\SearchBox.xaml.cs">
       <DependentUpon>SearchBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Services\HowLongToBeatSearchData.cs" />
     <Compile Include="Services\HowLongToBeatDatabase.cs" />
+    <Compile Include="Services\HowLongToBeatSearchRoot.cs" />
     <Compile Include="Services\OldToNew.cs" />
     <Compile Include="Views\HowLongToBeatSelect.xaml.cs">
       <DependentUpon>HowLongToBeatSelect.xaml</DependentUpon>

--- a/source/Models/HltbSearchData.cs
+++ b/source/Models/HltbSearchData.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace HowLongToBeat.Services
+namespace HowLongToBeat.Models
 {
-    class HowLongToBeatSearchData
+    class HltbSearchData
     {
         public int count { get; set; }
         public int game_id { get; set; }

--- a/source/Models/HltbSearchRoot.cs
+++ b/source/Models/HltbSearchRoot.cs
@@ -4,18 +4,18 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace HowLongToBeat.Services
+namespace HowLongToBeat.Models
 {
-    class HowLongToBeatSearchRoot
+    class HltbSearchRoot
     {
         public string color { get; set; }
         public string title { get; set; }
         public string category { get; set; }
         public int count { get; set; }
         public int pageCurrent { get; set; }
-        public int pageTotal { get; set; }
+        public int? pageTotal { get; set; }
         public int pageSize { get; set; }
-        public List<HowLongToBeatSearchData> data { get; set; }
+        public List<HltbSearchData> data { get; set; }
         public object displayModifier { get; set; }
     }
 }

--- a/source/Models/HltbUserGameList.cs
+++ b/source/Models/HltbUserGameList.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HowLongToBeat.Models
+{
+    class HltbUserGameList
+    {
+        public int game_id { get; set; }
+        public string custom_title { get; set; }
+        public string platform { get; set; }
+        public int list_playing { get; set; }
+        public int list_backlog { get; set; }
+        public int list_replay { get; set; }
+        public int list_custom { get; set; }
+        public int list_custom2 { get; set; }
+        public int list_custom3 { get; set; }
+        public int list_comp { get; set; }
+        public int list_retired { get; set; }
+        public int invested_sp { get; set; }
+        public int invested_spd { get; set; }
+        public int invested_co { get; set; }
+        public int invested_mp { get; set; }
+        public string date_complete { get; set; }
+        public string date_added { get; set; }
+        public int release_year { get; set; }
+        public string release_world { get; set; }
+    }
+}

--- a/source/Models/HltbUserGamesList.cs
+++ b/source/Models/HltbUserGamesList.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HowLongToBeat.Models
+{
+    public class Data
+    {
+        public int count { get; set; }
+        public List<GamesList> gamesList { get; set; }
+        public int total { get; set; }
+        public List<PlatformList> platformList { get; set; }
+        public SummaryData summaryData { get; set; }
+    }
+
+    public class GamesList
+    {
+        public int id { get; set; }
+        public string custom_title { get; set; }
+        public string platform { get; set; }
+        public string play_storefront { get; set; }
+        public int list_playing { get; set; }
+        public int list_backlog { get; set; }
+        public int list_replay { get; set; }
+        public int list_custom { get; set; }
+        public int list_custom2 { get; set; }
+        public int list_custom3 { get; set; }
+        public int list_comp { get; set; }
+        public int list_retired { get; set; }
+        public int comp_main { get; set; }
+        public int comp_plus { get; set; }
+        public int comp_100 { get; set; }
+        public int comp_speed { get; set; }
+        public int comp_speed100 { get; set; }
+        public string comp_main_notes { get; set; }
+        public string comp_plus_notes { get; set; }
+        public string comp_100_notes { get; set; }
+        public string comp_speed_notes { get; set; }
+        public string comp_speed100_notes { get; set; }
+        public int invested_pro { get; set; }
+        public int invested_sp { get; set; }
+        public int invested_spd { get; set; }
+        public int invested_co { get; set; }
+        public int invested_mp { get; set; }
+        public int play_count { get; set; }
+        public int review_score { get; set; }
+        public string review_notes { get; set; }
+        public string retired_notes { get; set; }
+        public string date_complete { get; set; }
+        public string date_updated { get; set; }
+        public string play_video { get; set; }
+        public string play_notes { get; set; }
+        public int game_id { get; set; }
+        public string game_image { get; set; }
+        public string game_type { get; set; }
+        public string release_world { get; set; }
+        public int comp_all { get; set; }
+        public int comp_all_g { get; set; }
+        public int review_score_g { get; set; }
+    }
+
+    public class PlatformList
+    {
+        public string platform { get; set; }
+        public int count_total { get; set; }
+    }
+
+    public class HltbUserGamesList
+    {
+        public Data data { get; set; }
+    }
+
+    public class SummaryData
+    {
+        public int playCount { get; set; }
+        public int dlcCount { get; set; }
+        public int reviewTotal { get; set; }
+        public int reviewCount { get; set; }
+        public int totalPlayedSp { get; set; }
+        public int totalPlayedMp { get; set; }
+        public int toBeatListed { get; set; }
+        public int uniqueGameCount { get; set; }
+    }
+}

--- a/source/Models/HltbUserStatsGamesList.cs
+++ b/source/Models/HltbUserStatsGamesList.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace HowLongToBeat.Models
 {
-    class HltbUserGameList
+    class HltbUserStatsGamesList
     {
         public int game_id { get; set; }
         public string custom_title { get; set; }
@@ -25,7 +25,7 @@ namespace HowLongToBeat.Models
         public int invested_mp { get; set; }
         public string date_complete { get; set; }
         public string date_added { get; set; }
-        public int release_year { get; set; }
+        public int? release_year { get; set; }
         public string release_world { get; set; }
     }
 }

--- a/source/Services/HowLongToBeatClient.cs
+++ b/source/Services/HowLongToBeatClient.cs
@@ -193,7 +193,8 @@ namespace HowLongToBeat.Services
 
                 HttpRequestMessage requestMessage = new HttpRequestMessage();
 
-                requestMessage.Content = new StringContent("{\"searchType\":\"games\",\"searchTerms\":[\"" + Name + "\"],\"searchPage\":1,\"size\":20,\"searchOptions\":{\"games\":{\"userId\":0,\"platform\":\"" + Platform + "\",\"sortCategory\":\"popular\",\"rangeCategory\":\"main\",\"rangeTime\":{\"min\":0,\"max\":0},\"gameplay\":{\"perspective\":\"\",\"flow\":\"\",\"genre\":\"\"},\"modifier\":\"\"},\"users\":{\"sortCategory\":\"postcount\"},\"filter\":\"\",\"sort\":0,\"randomizer\":0}}", Encoding.UTF8, "application/json");
+                var searchTerms = Name.Split(' ');
+                requestMessage.Content = new StringContent("{\"searchType\":\"games\",\"searchTerms\":[" + String.Join(",", searchTerms.Select(x => "\"" + x + "\"")) + "],\"searchPage\":1,\"size\":20,\"searchOptions\":{\"games\":{\"userId\":0,\"platform\":\"" + Platform + "\",\"sortCategory\":\"popular\",\"rangeCategory\":\"main\",\"rangeTime\":{\"min\":0,\"max\":0},\"gameplay\":{\"perspective\":\"\",\"flow\":\"\",\"genre\":\"\"},\"modifier\":\"\"},\"users\":{\"sortCategory\":\"postcount\"},\"filter\":\"\",\"sort\":0,\"randomizer\":0}}", Encoding.UTF8, "application/json");
 
                 HttpResponseMessage response = await httpClient.PostAsync(UrlSearch, requestMessage.Content);
                 var json = await response.Content.ReadAsStringAsync();

--- a/source/Services/HowLongToBeatClient.cs
+++ b/source/Services/HowLongToBeatClient.cs
@@ -82,7 +82,8 @@ namespace HowLongToBeat.Services
 
         private const string UrlUserStats = UrlBase + "user?n={0}&s=stats";
         private const string UrlUserStatsMore = UrlBase + "user_stats_more";
-        private const string UrlUserStatsGameList = UrlBase + "api/user/{0}/stats";
+        private const string UrlUserStatsGamesList = UrlBase + "api/user/{0}/stats";
+        private const string UrlUserGamesList = UrlBase + "api/user/{0}/games/list";
         private const string UrlUserStatsGameDetails = UrlBase + "user_games_detail";
 
         private const string UrlPostData = UrlBase + "submit";
@@ -409,36 +410,25 @@ namespace HowLongToBeat.Services
             return data;
         }
 
-        private List<HltbUserGameList> GetUserGamesList(bool WithDateUpdate = false)
+        private HltbUserGamesList GetUserGamesList(bool WithDateUpdate = false)
         {
             try
             {
                 List<HttpCookie> Cookies = WebViewOffscreen.GetCookies();
-                Cookies = Cookies.Where(x => x != null && x.Domain != null && x.Domain.Contains("hltb", StringComparison.InvariantCultureIgnoreCase)).ToList();
+                Cookies = Cookies.Where(x => x != null && x.Domain != null && (x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase) || x.Domain.Contains("hltb", StringComparison.InvariantCultureIgnoreCase))).ToList();
 
-                HttpClient httpClient = new HttpClient();
+                string payload = "{\"user_id\":" + UserId + ",\"lists\":[\"playing\",\"completed\",\"retired\"],\"set_playstyle\":\"comp_all\",\"name\":\"\",\"platform\":\"\",\"storefront\":\"\",\"sortBy\":\"\",\"sortFlip\":0,\"view\":\"\",\"limit\":1000,\"currentUserHome\":true}";
+                string json = Web.PostStringDataPayload(string.Format(UrlUserGamesList, UserId), payload, Cookies).GetAwaiter().GetResult();
 
-                httpClient.DefaultRequestHeaders.Add("User-Agent", Web.UserAgent);
-                httpClient.DefaultRequestHeaders.Add("origin", "https://howlongtobeat.com");
-                httpClient.DefaultRequestHeaders.Add("referer", "https://howlongtobeat.com");
-
-                HttpRequestMessage requestMessage = new HttpRequestMessage();
-
-                requestMessage.Content = new StringContent("{\"category\":\"user_beat\",\"platform\":\"\",\"storefront\":\"\",\"year\":\"\"}", Encoding.UTF8, "application/json");
-                
-                HttpResponseMessage response = httpClient.PostAsync(string.Format(UrlUserStatsGameList, "168540"), requestMessage.Content).GetAwaiter().GetResult();
-                var json = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-
-                List<HltbUserGameList> hltbUserGameList = new List<HltbUserGameList>();
-
-                hltbUserGameList = JsonConvert.DeserializeObject<List<HltbUserGameList>>(json);
+                HltbUserGamesList hltbUserGameList = new HltbUserGamesList();
+                hltbUserGameList = JsonConvert.DeserializeObject<HltbUserGamesList>(json);
 
                 return hltbUserGameList;
             }
             catch (Exception ex)
             {
                 Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return new List<HltbUserGameList>();
+                return new HltbUserGamesList();
             }
         }
 
@@ -447,7 +437,7 @@ namespace HowLongToBeat.Services
             try
             {
                 List<HttpCookie> Cookies = WebViewOffscreen.GetCookies();
-                Cookies = Cookies.Where(x => x != null && x.Domain != null && x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase)).ToList();
+                Cookies = Cookies.Where(x => x != null && x.Domain != null && (x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase) || x.Domain.Contains("hltb", StringComparison.InvariantCultureIgnoreCase))).ToList();
 
                 FormUrlEncodedContent formContent = new FormUrlEncodedContent(new[]
                 {
@@ -465,194 +455,70 @@ namespace HowLongToBeat.Services
             }
         }
 
-        private TitleList GetTitleList(IElement element)
+        private TitleList GetTitleList(GamesList x)
         {
             try
             {
-                TitleList titleList = new TitleList();
-
-                IHtmlCollection<IElement> tr = element.QuerySelectorAll("tr");
-                IHtmlCollection<IElement> td = tr[0].QuerySelectorAll("td");
-
-                titleList.UserGameId = element.GetAttribute("id").Replace("user_sel_", string.Empty).Trim();
-                titleList.GameName = WebUtility.HtmlDecode(td[0].QuerySelector("a").InnerHtml.Trim());
-                titleList.Platform = WebUtility.HtmlDecode(td[0].QuerySelector("span").InnerHtml.Trim());
-                titleList.Id = int.Parse(td[0].QuerySelector("a").GetAttribute("href").Replace("game?id=", string.Empty));
-
-                string sCurrentTime = td[1].InnerHtml;
-                titleList.CurrentTime = ConvertStringToLongUser(sCurrentTime);
-
-                HltbPostData hltbPostData = GetSubmitData(titleList.GameName, titleList.UserGameId);
-                if (hltbPostData != null)
+                DateTime.TryParse(x.date_updated, out DateTime LastUpdate);
+                DateTime.TryParse(x.date_complete, out DateTime Completion);
+                DateTime? CompletionFinal = null;
+                if (Completion != default) 
                 {
-                    string tempCurrentTime = (hltbPostData.protime_h.IsNullOrEmpty()) ? string.Empty : hltbPostData.protime_h + "h";
-                    tempCurrentTime += (hltbPostData.protime_m.IsNullOrEmpty()) ? string.Empty : " " + hltbPostData.protime_m + "m";
-                    tempCurrentTime += (hltbPostData.protime_s.IsNullOrEmpty()) ? string.Empty : " " + hltbPostData.protime_s + "s";
-
-                    titleList.CurrentTime = ConvertStringToLongUser(tempCurrentTime.Trim());
-
-                    titleList.IsReplay = (hltbPostData.play_num == 2);
-                    titleList.IsRetired = (hltbPostData.list_rt == "1");
+                    CompletionFinal = Completion;
                 }
 
-                string response = GetUserGamesDetail(titleList.UserGameId);
-                if (response.IsNullOrEmpty())
+                TitleList titleList = new TitleList
                 {
-                    logger.Warn($"No details for {titleList.GameName}");
-                    return null;
+                    UserGameId = x.game_id.ToString(),
+                    GameName = x.custom_title,
+                    Platform = x.platform,
+                    Id = x.id,
+                    CurrentTime = x.invested_pro,
+                    IsReplay = x.list_replay == 1,
+                    IsRetired = x.list_retired == 1,
+                    Storefront = x.play_storefront,
+                    LastUpdate = LastUpdate,
+                    Completion = CompletionFinal,
+                    HltbUserData = new HltbData
+                    {
+                        MainStory = x.comp_main,
+                        MainExtra = x.comp_plus,
+                        Completionist = x.comp_100,
+                        Solo = 0,
+                        CoOp = x.invested_co,
+                        Vs = x.invested_mp
+                    },
+                    GameStatuses = new List<GameStatus>()
+                };
+
+                if (x.list_backlog == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Backlog });
                 }
 
-                HtmlParser parser = new HtmlParser();
-                IHtmlDocument htmlDocument = parser.Parse(response);
-
-                IHtmlCollection<IElement> GameDetails = htmlDocument.QuerySelectorAll("div.user_game_detail > div");
-
-                // Game status type
-                titleList.GameStatuses = new List<GameStatus>();
-                foreach (IElement GameStatus in GameDetails[0].QuerySelectorAll("span"))
+                if (x.list_comp == 1)
                 {
-                    switch (GameStatus.InnerHtml.ToLower())
-                    {
-                        case "playing":
-                            titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Playing });
-                            break;
-                        case "backlog":
-                            titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Backlog });
-                            break;
-                        case "replays":
-                            titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Replays });
-                            break;
-                        case "custom tab":
-                            titleList.GameStatuses.Add(new GameStatus { Status = StatusType.CustomTab });
-                            break;
-                        case "completed":
-                            titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Completed });
-                            break;
-                        case "retired":
-                            titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Retired });
-                            break;
-                    }
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Completed });
                 }
 
-                // Game status time
-                int iPosUserData = 1;
-                if (GameDetails[1].InnerHtml.ToLower().Contains("<h5>progress</h5>"))
+                if (x.list_custom == 1)
                 {
-                    List<string> ListTime = GameDetails[1].QuerySelector("span").InnerHtml
-                        .Replace("<strong>", string.Empty).Replace("</strong>", string.Empty)
-                        .Split('/').ToList();
-
-                    for (int i = 0; i < titleList.GameStatuses.Count; i++)
-                    {
-                        titleList.GameStatuses[i].Time = ConvertStringToLongUser(ListTime[i]);
-                    }
-
-                    iPosUserData = 2;
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.CustomTab });
                 }
 
-                // Storefront
-                IElement elStorefront = htmlDocument.QuerySelectorAll("h5").Where(x => x.InnerHtml.ToLower().Contains("storefront")).FirstOrDefault();
-                if (elStorefront != null)
+                if (x.list_playing == 1)
                 {
-                    titleList.Storefront = WebUtility.HtmlDecode(elStorefront.ParentElement?.QuerySelector("div")?.InnerHtml?.Trim());
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Playing });
                 }
 
-                // Updated - sec - min - hour - day - week - month - year 
-                IElement elUpdated = htmlDocument.QuerySelectorAll("h5").Where(x => x.InnerHtml.ToLower().Contains("updated")).FirstOrDefault();
-                if (elUpdated != null)
+                if (x.list_replay == 1)
                 {
-                    string dataUpdate = WebUtility.HtmlDecode(elUpdated.ParentElement?.QuerySelector("p")?.InnerHtml?.Trim());
-                    string doubleString = Regex.Replace(dataUpdate, @"[^\d.\d]", string.Empty).Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
-                    double.TryParse(doubleString, out double doubleData);
-
-                    if (dataUpdate.Contains("sec", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        titleList.LastUpdate = DateTime.Now.AddSeconds(-1 * doubleData);
-                    }
-
-                    if (dataUpdate.Contains("min", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        titleList.LastUpdate = DateTime.Now.AddMinutes(-1 * doubleData);
-                    }
-
-                    if (dataUpdate.Contains("hour", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        titleList.LastUpdate = DateTime.Now.AddHours(-1 * doubleData);
-                    }
-
-                    if (dataUpdate.Contains("day", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        titleList.LastUpdate = DateTime.Now.AddDays(-1 * doubleData);
-                    }
-
-                    if (dataUpdate.Contains("week", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        doubleData = doubleData * 7;
-                        titleList.LastUpdate = DateTime.Now.AddDays(-1 * doubleData);
-                    }
-
-                    if (dataUpdate.Contains("month", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        double days = (doubleData - (int)doubleData) * 30;
-                        titleList.LastUpdate = DateTime.Now.AddMonths((int)(-1 * doubleData)).AddDays(days);
-                    }
-
-                    if (dataUpdate.Contains("year", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        titleList.LastUpdate = DateTime.Now.AddYears((int)(-1 * doubleData));
-                    }
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Replays });
                 }
 
-                // User data
-                titleList.HltbUserData = new HltbData();
-                if (hltbPostData != null)
+                if (x.list_retired == 1)
                 {
-                    // Completion date
-                    string tempTime = hltbPostData.compyear + "-" + hltbPostData.compmonth + "-" + hltbPostData.compday;
-                    if (DateTime.TryParse(tempTime, out DateTime dateValue))
-                    {
-                        titleList.Completion = Convert.ToDateTime(dateValue);
-                    }
-                    else
-                    {
-                        logger.Warn($"Impossible to parse datetime: {tempTime}");
-                        titleList.Completion = null;
-                    }
-
-                    int.TryParse(hltbPostData.c_main_h, out int c_main_h);
-                    int.TryParse(hltbPostData.c_main_m, out int c_main_m);
-                    int.TryParse(hltbPostData.c_main_s, out int c_main_s);
-                    titleList.HltbUserData.MainStory = c_main_h * 3600 + c_main_m * 60 + c_main_s;
-
-                    int.TryParse(hltbPostData.c_plus_h, out int c_plus_h);
-                    int.TryParse(hltbPostData.c_plus_m, out int c_plus_m);
-                    int.TryParse(hltbPostData.c_plus_s, out int c_plus_s);
-                    titleList.HltbUserData.MainExtra = c_plus_h * 3600 + c_plus_m * 60 + c_plus_s;
-
-                    int.TryParse(hltbPostData.c_100_h, out int c_100_h);
-                    int.TryParse(hltbPostData.c_100_m, out int c_100_m);
-                    int.TryParse(hltbPostData.c_100_s, out int c_100_s);
-                    titleList.HltbUserData.Completionist = c_100_h * 3600 + c_100_m * 60 + c_100_s;
-
-                    int.TryParse(hltbPostData.cotime_h, out int cotime_h);
-                    int.TryParse(hltbPostData.cotime_m, out int cotime_m);
-                    int.TryParse(hltbPostData.cotime_s, out int cotime_s);
-                    titleList.HltbUserData.CoOp = cotime_h * 3600 + cotime_m * 60 + cotime_s;
-
-                    int.TryParse(hltbPostData.mptime_h, out int mptime_h);
-                    int.TryParse(hltbPostData.mptime_m, out int mptime_m);
-                    int.TryParse(hltbPostData.mptime_s, out int mptime_s);
-                    titleList.HltbUserData.Vs = mptime_h * 3600 + mptime_m * 60 + mptime_s;
-                }
-
-                for (int i = 0; i < GameDetails[iPosUserData].Children.Count(); i++)
-                {
-                    if (GameDetails[iPosUserData].Children[i].InnerHtml.ToLower().Contains("solo"))
-                    {
-                        i++;
-                        string tempTime = GameDetails[iPosUserData]?.Children[i]?.QuerySelector("span")?.InnerHtml;
-                        titleList.HltbUserData.Solo = ConvertStringToLongUser(tempTime);
-                    }
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Retired });
                 }
 
                 Common.LogDebug(true, $"titleList: {Serialization.ToJson(titleList)}");
@@ -671,7 +537,7 @@ namespace HowLongToBeat.Services
             try
             {
                 List<HttpCookie> Cookies = WebViewOffscreen.GetCookies();
-                Cookies = Cookies.Where(x => x != null && x.Domain != null && x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase)).ToList();
+                Cookies = Cookies.Where(x => x != null && x.Domain != null && (x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase) || x.Domain.Contains("hltb", StringComparison.InvariantCultureIgnoreCase))).ToList();
 
                 string response = Web.DownloadStringData(string.Format(UrlPostDataEdit, UserGameId), Cookies).GetAwaiter().GetResult();
                 if (response.IsNullOrEmpty())
@@ -968,34 +834,23 @@ namespace HowLongToBeat.Services
             if (GetIsUserLoggedIn())
             {
                 hltbUserStats = new HltbUserStats();
-                hltbUserStats.Login = (UserLogin.IsNullOrEmpty()) ? HowLongToBeat.PluginDatabase.Database.UserHltbData.Login : UserLogin;
+                hltbUserStats.Login = UserLogin.IsNullOrEmpty() ? HowLongToBeat.PluginDatabase.Database.UserHltbData.Login : UserLogin;
                 hltbUserStats.UserId = (UserId == 0) ? HowLongToBeat.PluginDatabase.Database.UserHltbData.UserId : UserId;
                 hltbUserStats.TitlesList = new List<TitleList>();
 
-                List<HltbUserGameList> response = GetUserGamesList();
+                HltbUserGamesList response = GetUserGamesList();
                 if (response == null)
                 {
                     return null;
                 }
 
-                Dictionary<string, DateTime> ListGameWithDateUpdate = GetListGameWithDateUpdate();
-
                 try
                 {
-                    HtmlParser parser = new HtmlParser();
-                    IHtmlDocument htmlDocument = parser.Parse("");
-
-                    foreach (IElement ListGame in htmlDocument.QuerySelectorAll("table.user_game_list tbody"))
+                    response.data.gamesList.ForEach(x =>
                     {
-                        TitleList titleList = GetTitleList(ListGame);
-                        DateTime? dateUpdate = ListGameWithDateUpdate.Where(x => x.Key.IsEqual(titleList.UserGameId))?.FirstOrDefault().Value;
-                        if (dateUpdate != null && (DateTime)dateUpdate != default(DateTime))
-                        {
-                            titleList.LastUpdate = (DateTime)dateUpdate;
-                        }
-
+                        TitleList titleList = GetTitleList(x);
                         hltbUserStats.TitlesList.Add(titleList);
-                    }
+                    });
                 }
                 catch (Exception ex)
                 {
@@ -1021,48 +876,14 @@ namespace HowLongToBeat.Services
         {
             if (GetIsUserLoggedIn())
             {
-                List<HltbUserGameList> response = GetUserGamesList();
-                if (response == null)
-                {
-                    return null;
-                }
-
-                Dictionary<string, DateTime> ListGameWithDateUpdate = GetListGameWithDateUpdate();
-
                 try
                 {
-                    HtmlParser parser = new HtmlParser();
-                    IHtmlDocument htmlDocument = parser.Parse("");
-
-                    foreach (IElement ListGame in htmlDocument.QuerySelectorAll("table.user_game_list tbody"))
-                    {
-                        IHtmlCollection<IElement> tr = ListGame.QuerySelectorAll("tr");
-                        IHtmlCollection<IElement> td = tr[0].QuerySelectorAll("td");
-
-                        int Id = int.Parse(td[0].QuerySelector("a").GetAttribute("href").Replace("game?id=", string.Empty));
-
-                        if (Id != game_id)
-                        {
-                            continue;
-                        }
-
-                        TitleList titleList = GetTitleList(ListGame);
-
-                        DateTime? dateUpdate = ListGameWithDateUpdate.Where(x => x.Key.IsEqual(titleList.UserGameId))?.FirstOrDefault().Value;
-                        if (dateUpdate != null)
-                        {
-                            titleList.LastUpdate = (DateTime)dateUpdate;
-                        }
-
-                        Common.LogDebug(true, $"titleList: {Serialization.ToJson(titleList)}");
-
-                        return titleList;
-                    }
+                    HltbUserStats data = GetUserData();
+                    return data?.TitlesList?.Find(x => x.UserGameId.IsEqual(game_id.ToString()));
                 }
                 catch (Exception ex)
                 {
                     Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                    return null;
                 }
 
                 return null;
@@ -1082,33 +903,12 @@ namespace HowLongToBeat.Services
 
         public bool EditIdExist(string UserGameId)
         {
-            return GetUserGamesList().FirstOrDefault().game_id.Equals(UserGameId);
+            return GetUserGamesList().data.gamesList.FirstOrDefault().game_id.Equals(UserGameId);
         }
 
         public string FindIdExisting(string GameId)
         {
-            try
-            {
-                List<HltbUserGameList> UserGamesList = GetUserGamesList();
-                HtmlParser parser = new HtmlParser();
-                IHtmlDocument htmlDocument = parser.Parse("");
-
-                IElement element = htmlDocument.QuerySelectorAll("a").Where(x => x.GetAttribute("href").Contains($"game?id={GameId}")).FirstOrDefault();
-
-                if (element != null)
-                {
-                    return element.GetAttribute("id").ToLower().Replace("user_play_sel_", string.Empty);
-                }
-                else
-                {
-                    return string.Empty;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return null;
-            }
+            return GetUserGamesList()?.data?.gamesList?.Find(x => x.game_id.Equals(GameId))?.id.ToString() ?? null;
         }
         #endregion
 
@@ -1223,7 +1023,7 @@ namespace HowLongToBeat.Services
                     
 
                     List<HttpCookie> Cookies = WebViewOffscreen.GetCookies();
-                    Cookies = Cookies.Where(x => x != null && x.Domain != null && x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase)).ToList();
+                    Cookies = Cookies.Where(x => x != null && x.Domain != null && (x.Domain.Contains("howlongtobeat", StringComparison.InvariantCultureIgnoreCase) || x.Domain.Contains("hltb", StringComparison.InvariantCultureIgnoreCase))).ToList();
 
                     FormUrlEncodedContent formContent = new FormUrlEncodedContent(data);
                     string response = await Web.PostStringDataCookies(UrlPostData, formContent, Cookies);

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -221,7 +221,7 @@ namespace HowLongToBeat.Services
             }, globalProgressOptions);
         }
 
-        
+
         public override GameHowLongToBeat Get(Guid Id, bool OnlyCache = false, bool Force = false)
         {
             GameHowLongToBeat gameHowLongToBeat = GetOnlyCache(Id);
@@ -429,7 +429,7 @@ namespace HowLongToBeat.Services
                     {
                         AddData(game);
                     }
-                    
+
                     activateGlobalProgress.CurrentProgressValue++;
                 }
 
@@ -478,7 +478,32 @@ namespace HowLongToBeat.Services
                 {
                     Common.LogError(ex, false, $"Tag insert error with {game.Name}", true, PluginName, string.Format(resources.GetString("LOCCommonNotificationTagError"), game.Name));
                 }
+            } else
+            {
+                if (game.TagIds != null)
+                {
+                    game.TagIds.Add((Guid)AddNoHltbDataTag());
+                }
+                else
+                {
+                    game.TagIds = new List<Guid> { (Guid)AddNoHltbDataTag() };
+                }
+
+                if (!noUpdate)
+                {
+                    Application.Current.Dispatcher?.Invoke(() =>
+                    {
+                        PlayniteApi.Database.Games.Update(game);
+                        game.OnPropertyChanged();
+                    }, DispatcherPriority.Send);
+                }
+
             }
+        }
+
+        private Guid? AddNoHltbDataTag()
+        {
+            return CheckTagExist($"{resources.GetString("LOCNoData")}");
         }
 
         private Guid? FindGoodPluginTags(HltbDataUser hltbDataUser)

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -388,15 +388,16 @@ namespace HowLongToBeat.Services
                 {
                     Common.LogError(ex, false, $"Tag insert error with {game.Name}", true, PluginName, string.Format(resources.GetString("LOCCommonNotificationTagError"), game.Name));
                 }
-            } else
+            } 
+            else if (TagMissing)
             {
                 if (game.TagIds != null)
                 {
-                    game.TagIds.Add((Guid)AddNoHltbDataTag());
+                    game.TagIds.Add((Guid)AddNoDataTag());
                 }
                 else
                 {
-                    game.TagIds = new List<Guid> { (Guid)AddNoHltbDataTag() };
+                    game.TagIds = new List<Guid> { (Guid)AddNoDataTag() };
                 }
 
                 if (!noUpdate)
@@ -411,10 +412,6 @@ namespace HowLongToBeat.Services
             }
         }
 
-        private Guid? AddNoHltbDataTag()
-        {
-            return CheckTagExist($"{resources.GetString("LOCNoData")}");
-        }
 
         private Guid? FindGoodPluginTags(HltbDataUser hltbDataUser)
         {

--- a/source/Services/HowLongToBeatSearchData.cs
+++ b/source/Services/HowLongToBeatSearchData.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HowLongToBeat.Services
+{
+    class HowLongToBeatSearchData
+    {
+        public int count { get; set; }
+        public int game_id { get; set; }
+        public string game_name { get; set; }
+        public int game_name_date { get; set; }
+        public string game_alias { get; set; }
+        public string game_type { get; set; }
+        public string game_image { get; set; }
+        public int comp_lvl_combine { get; set; }
+        public int comp_lvl_sp { get; set; }
+        public int comp_lvl_co { get; set; }
+        public int comp_lvl_mp { get; set; }
+        public int comp_lvl_spd { get; set; }
+        public int comp_main { get; set; }
+        public int comp_plus { get; set; }
+        public int comp_100 { get; set; }
+        public int comp_all { get; set; }
+        public int comp_main_count { get; set; }
+        public int comp_plus_count { get; set; }
+        public int comp_100_count { get; set; }
+        public int comp_all_count { get; set; }
+        public int invested_co { get; set; }
+        public int invested_mp { get; set; }
+        public int invested_co_count { get; set; }
+        public int invested_mp_count { get; set; }
+        public int count_comp { get; set; }
+        public int count_speedrun { get; set; }
+        public int count_backlog { get; set; }
+        public int count_review { get; set; }
+        public int review_score { get; set; }
+        public int count_playing { get; set; }
+        public int count_retired { get; set; }
+        public string profile_dev { get; set; }
+        public int profile_popular { get; set; }
+        public int profile_steam { get; set; }
+        public string profile_platform { get; set; }
+        public int release_world { get; set; }
+        
+    }
+}

--- a/source/Services/HowLongToBeatSearchRoot.cs
+++ b/source/Services/HowLongToBeatSearchRoot.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HowLongToBeat.Services
+{
+    class HowLongToBeatSearchRoot
+    {
+        public string color { get; set; }
+        public string title { get; set; }
+        public string category { get; set; }
+        public int count { get; set; }
+        public int pageCurrent { get; set; }
+        public int pageTotal { get; set; }
+        public int pageSize { get; set; }
+        public List<HowLongToBeatSearchData> data { get; set; }
+        public object displayModifier { get; set; }
+    }
+}

--- a/source/packages.config
+++ b/source/packages.config
@@ -4,7 +4,8 @@
   <package id="FuzzySharp" version="2.0.2" targetFramework="net462" />
   <package id="LiveCharts" version="0.9.7" targetFramework="net462" />
   <package id="LiveCharts.Wpf" version="0.9.7" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.2.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.3.0" targetFramework="net462" />
   <package id="System.IO.Abstractions" version="2.1.0.227" targetFramework="net462" />
   <package id="YamlDotNet" version="5.4.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
When using either of these options

![image](https://user-images.githubusercontent.com/11045596/180205030-4f33c716-51c0-48f9-84c5-bad006d5b310.png)

If the game does not have any HLTB data then it will add a tag for "Data not searched for"

I have also added an option within the "Add plugin tag..." option to only add tags to games that are missing data

![image](https://user-images.githubusercontent.com/11045596/180205285-7f439837-865e-4a18-9a38-5225c3843916.png)

