### PR TITLE
Implements Platform Matching

### DIFF
--- a/source/Behaviors/SelectorBehaviors.cs
+++ b/source/Behaviors/SelectorBehaviors.cs
@@ -8,7 +8,7 @@ namespace HowLongToBeat.Behaviors {
 
         public class EnumSelector {
             public Enum Value { get; set; }
-            public string DisplayName { get; set; }
+            public string DisplayText { get; set; }
         }
 
         private static readonly DependencyProperty EnumSourceProperty =
@@ -31,13 +31,13 @@ namespace HowLongToBeat.Behaviors {
             }
 
             var select = (System.Windows.Controls.Primitives.Selector)obj;
-            select.DisplayMemberPath = nameof(EnumSelector.DisplayName);
+            select.DisplayMemberPath = nameof(EnumSelector.DisplayText);
             select.SelectedValuePath = nameof(EnumSelector.Value);
             select.Items.Clear();
 
             var values = Enum.GetValues((Type)args.NewValue);
             foreach (Enum value in values) {
-                select.Items.Add(new EnumSelector { Value = value, DisplayName = value.GetDescription() });
+                select.Items.Add(new EnumSelector { Value = value, DisplayText = value.GetDescription() });
             }
         }
 

--- a/source/Behaviors/SelectorBehaviors.cs
+++ b/source/Behaviors/SelectorBehaviors.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+
+namespace HowLongToBeat.Behaviors {
+
+    public class SelectorBehaviors {
+
+        public class EnumSelector {
+            public Enum Value { get; set; }
+            public string DisplayName { get; set; }
+        }
+
+        private static readonly DependencyProperty EnumSourceProperty =
+              DependencyProperty.RegisterAttached(
+                    "EnumSource", typeof(Type), typeof(SelectorBehaviors),
+                    new PropertyMetadata(new PropertyChangedCallback(EnumSourcePropertyChanged)));
+
+        public static Type GetEnumSource(DependencyObject obj) {
+            return (Type)obj.GetValue(EnumSourceProperty);
+        }
+
+        public static void SetEnumSource(DependencyObject obj, Type value) {
+            obj.SetValue(EnumSourceProperty, value);
+        }
+
+        private static void EnumSourcePropertyChanged(
+              DependencyObject obj, DependencyPropertyChangedEventArgs args) {
+            if (DesignerProperties.GetIsInDesignMode(obj) || args.NewValue == null) {
+                return;
+            }
+
+            var select = (System.Windows.Controls.Primitives.Selector)obj;
+            select.DisplayMemberPath = nameof(EnumSelector.DisplayName);
+            select.SelectedValuePath = nameof(EnumSelector.Value);
+            select.Items.Clear();
+
+            var values = Enum.GetValues((Type)args.NewValue);
+            foreach (Enum value in values) {
+                select.Items.Add(new EnumSelector { Value = value, DisplayName = value.GetDescription() });
+            }
+        }
+
+    }
+
+}

--- a/source/HowLongToBeat.csproj
+++ b/source/HowLongToBeat.csproj
@@ -105,6 +105,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Behaviors\SelectorBehaviors.cs" />
     <Compile Include="Controls\PluginButton.xaml.cs">
       <DependentUpon>PluginButton.xaml</DependentUpon>
     </Compile>
@@ -116,6 +117,7 @@
     </Compile>
     <Compile Include="HowLongToBeat.cs" />
     <Compile Include="HowLongToBeatSettings.cs" />
+    <Compile Include="Models\HltbPlatform.cs" />
     <Compile Include="Models\GameHowLongToBeat.cs" />
     <Compile Include="Models\GameHowLongToBeatCollection.cs" />
     <Compile Include="Models\HltbDataUser.cs" />

--- a/source/HowLongToBeatSettings.cs
+++ b/source/HowLongToBeatSettings.cs
@@ -175,6 +175,7 @@ namespace HowLongToBeat
 
 
         public List<Storefront> Storefronts { get; set; } = new List<Storefront>();
+        public List<HltbPlatformMatch> Platforms { get; set; } = new List<HltbPlatformMatch>();
         #endregion
 
         // Playnite serializes settings object to a JSON object and saves it as text file.
@@ -426,7 +427,6 @@ namespace HowLongToBeat
                     new Storefront { HltbStorefrontId = HltbStorefront.XboxStore }
                 };
             }
-
 
             if (Settings.ThumbLinearGradient == null && Settings.ThumbSolidColorBrush == null)
             {

--- a/source/Models/HltbPlatform.cs
+++ b/source/Models/HltbPlatform.cs
@@ -1,0 +1,204 @@
+﻿using Playnite.SDK.Data;
+using Playnite.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace HowLongToBeat.Models {
+
+    public enum HltbPlatform {
+
+        [Description("3DO")]
+        PANASONIC_3DO,
+        [Description("Amiga")]
+        AMIGA,
+        [Description("Amstrad CPC")]
+        AMSTRAD_CPC,
+        [Description("Android")]
+        ANDROID,
+        [Description("Apple II")]
+        APPLE_2,
+        [Description("Arcade")]
+        ARCADE,
+        [Description("Atari 2600")]
+        ATARI_2600,
+        [Description("Atari 5200")]
+        ATARI_5200,
+        [Description("Atari 7800")]
+        ATARI_7800,
+        [Description("Atari 8-bit Family")]
+        ATARI_8_BIT,
+        [Description("Atari Jaguar")]
+        ATARI_JAGUAR,
+        [Description("Atari Jaguar CD")]
+        ATARI_JAGUAR_CD,
+        [Description("Atari Lynx")]
+        ATARI_LYNX,
+        [Description("Atari ST")]
+        ATARI_ST,
+        [Description("BBC Micro")]
+        BBC_MICRO,
+        [Description("Browser")]
+        BROWSER,
+        [Description("ColecoVision")]
+        COLECOVISION,
+        [Description("Commodore 64")]
+        COMMODORE_64,
+        [Description("Dreamcast")]
+        DREAMCAST,
+        [Description("Emulated")]
+        EMULATED,
+        [Description("FM Towns")]
+        FM_TOWNS,
+        [Description("Game & Watch")]
+        GAME_WATCH,
+        [Description("Game Boy")]
+        GAME_BOY,
+        [Description("Game Boy Advance")]
+        GAME_BOY_ADVANCE,
+        [Description("Game Boy Color")]
+        GAME_BOY_COLOR,
+        [Description("Gear VR")]
+        GEAR_VR,
+        [Description("Google Stadia")]
+        GOOGLE_STADIA,
+        [Description("Intellivision")]
+        INTELLIVISION,
+        [Description("Interactive Movie")]
+        INTERACTIVE_MOVIE,
+        [Description("iOS")]
+        IOS,
+        [Description("Linux")]
+        LINUX,
+        [Description("Mac")]
+        MAC,
+        [Description("Mobile")]
+        MOBILE,
+        [Description("MSX")]
+        MSX,
+        [Description("N-Gage")]
+        N_GAGE,
+        [Description("NEC PC-8800")]
+        NEC_PC_8800,
+        [Description("NEC PC-9801/21")]
+        NEC_PC_9801,
+        [Description("NEC PC-FX")]
+        NEC_PC_FX,
+        [Description("Neo Geo")]
+        NEO_GEO,
+        [Description("Neo Geo CD")]
+        NEO_GEO_CD,
+        [Description("Neo Geo Pocket")]
+        NEO_GEO_POCKET,
+        [Description("NES")]
+        NES,
+        [Description("Nintendo 3DS")]
+        NINTENDO_3DS,
+        [Description("Nintendo 64")]
+        NINTENDO_64,
+        [Description("Nintendo DS")]
+        NINTENDO_DS,
+        [Description("Nintendo GameCube")]
+        NINTENDO_GAMECUBE,
+        [Description("Nintendo Switch")]
+        NINTENDO_SWITCH,
+        [Description("Oculus Go")]
+        OCULUS_GO,
+        [Description("Oculus Quest")]
+        OCULUS_QUEST,
+        [Description("OnLive")]
+        ONLIVE,
+        [Description("Ouya")]
+        OUYA,
+        [Description("PC")]
+        PC,
+        [Description("PC VR")]
+        PC_VR,
+        [Description("Philips CD-i")]
+        PHILIPS_CDI,
+        [Description("Philips Videopac G7000")]
+        PHILIPS_VIDEOPAC_G7000,
+        [Description("PlayStation")]
+        PLAYSTATION,
+        [Description("PlayStation 2")]
+        PLAYSTATION_2,
+        [Description("PlayStation 3")]
+        PLAYSTATION_3,
+        [Description("PlayStation 4")]
+        PLAYSTATION_4,
+        [Description("PlayStation 5")]
+        PLAYSTATION_5,
+        [Description("PlayStation Mobile")]
+        PLAYSTATION_MOBILE,
+        [Description("PlayStation Now")]
+        PLAYSTATION_NOW,
+        [Description("PlayStation Portable")]
+        PLAYSTATION_PORTABLE,
+        [Description("PlayStation Vita")]
+        PLAYSTATION_VITA,
+        [Description("PlayStation VR")]
+        PLAYSTATION_VR,
+        [Description("Plug & Play")]
+        PLUG_PLAY,
+        [Description("Sega 32X")]
+        SEGA_32X,
+        [Description("Sega CD")]
+        SEGA_CD,
+        [Description("Sega Game Gear")]
+        SEGA_GAME_GEAR,
+        [Description("Sega Master System")]
+        SEGA_MASTER_SYSTEM,
+        [Description("Sega Mega Drive/Genesis")]
+        SEGA_MEGA_DRIVE,
+        [Description("Sega Saturn")]
+        SEGA_SATURN,
+        [Description("SG-1000")]
+        SG_1000,
+        [Description("Sharp X68000")]
+        SHARP_X68000,
+        [Description("Super Nintendo")]
+        SUPER_NINTENDO,
+        [Description("Tiger Handheld")]
+        TIGER_HANDHELD,
+        [Description("TurboGrafx-16")]
+        TURBOGRAFX_16,
+        [Description("TurboGrafx-CD")]
+        TURBOGRAFX_CD,
+        [Description("Virtual Boy")]
+        VIRTUAL_BOY,
+        [Description("Wii")]
+        WII,
+        [Description("Wii U")]
+        WII_U,
+        [Description("Windows Phone")]
+        WINDOWS_PHONE,
+        [Description("WonderSwan")]
+        WONDERSWAN,
+        [Description("Xbox")]
+        XBOX,
+        [Description("Xbox 360")]
+        XBOX_360,
+        [Description("Xbox One")]
+        XBOX_ONE,
+        [Description("Xbox Series X/S")]
+        XBOS_SERIES_XS,
+        [Description("ZX Spectrum")]
+        ZX_SPECTRUM
+
+    }
+
+    public class HltbPlatformMatch {
+
+        private static readonly List<HltbPlatform> HLTB_PLATFORMS
+            = Enum.GetValues(typeof(HltbPlatform)).Cast<HltbPlatform>().ToList();
+
+        public Platform Platform { get; set; }
+        public HltbPlatform? HltbPlatform { get; set; } = null;
+
+        [DontSerialize]
+        public List<HltbPlatform> HltbPlatformList => HLTB_PLATFORMS;
+
+    }
+
+}

--- a/source/Models/HltbPlatform.cs
+++ b/source/Models/HltbPlatform.cs
@@ -188,7 +188,7 @@ namespace HowLongToBeat.Models {
 
     }
 
-    public class HltbPlatformMatch {
+    public class HltbPlatformMatch : IComparable<HltbPlatformMatch> {
 
         private static readonly List<HltbPlatform> HLTB_PLATFORMS
             = Enum.GetValues(typeof(HltbPlatform)).Cast<HltbPlatform>().ToList();
@@ -199,6 +199,9 @@ namespace HowLongToBeat.Models {
         [DontSerialize]
         public List<HltbPlatform> HltbPlatformList => HLTB_PLATFORMS;
 
+        public int CompareTo(HltbPlatformMatch other) {
+            return other == null ? 1 : Platform.Name.CompareTo(other.Platform.Name);
+        }
     }
 
 }

--- a/source/Models/HltbPlatform.cs
+++ b/source/Models/HltbPlatform.cs
@@ -190,14 +190,8 @@ namespace HowLongToBeat.Models {
 
     public class HltbPlatformMatch : IComparable<HltbPlatformMatch> {
 
-        private static readonly List<HltbPlatform> HLTB_PLATFORMS
-            = Enum.GetValues(typeof(HltbPlatform)).Cast<HltbPlatform>().ToList();
-
         public Platform Platform { get; set; }
         public HltbPlatform? HltbPlatform { get; set; } = null;
-
-        [DontSerialize]
-        public List<HltbPlatform> HltbPlatformList => HLTB_PLATFORMS;
 
         public int CompareTo(HltbPlatformMatch other) {
             return other == null ? 1 : Platform.Name.CompareTo(other.Platform.Name);

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -606,7 +606,7 @@ namespace HowLongToBeat.Services
                             return false;
                         }
                         HltbPlatform? match = PluginSettings.Settings.Platforms
-                                .Where(p => p.Platform == gamePlatform).FirstOrDefault()?.HltbPlatform;
+                                .Where(p => p.Platform.Equals(gamePlatform)).FirstOrDefault()?.HltbPlatform;
                         if (match != null) {
                             platform = match.GetDescription();
                         } else {

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -6,6 +6,7 @@ using Playnite.SDK.Models;
 using CommonPluginsShared.Collections;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -25,98 +26,6 @@ namespace HowLongToBeat.Services
     {
         public HowLongToBeat Plugin;
         public HowLongToBeatClient howLongToBeatClient;
-
-        public List<HltbPlatform> hltbPlatforms = new List<HltbPlatform>
-        {
-            new HltbPlatform() { Name = "3DO", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Amiga", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Amstrad CPC", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Android", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Apple II", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Arcade", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari 2600", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari 5200", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari 7800", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari 8-bit Family", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari Jaguar", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari Jaguar CD", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari Lynx", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Atari ST", Category = "All Platforms" },
-            new HltbPlatform() { Name = "BBC Micro", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Browser", Category = "All Platforms" },
-            new HltbPlatform() { Name = "ColecoVision", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Commodore 64", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Dreamcast", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Emulated", Category = "All Platforms" },
-            new HltbPlatform() { Name = "FM Towns", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Game & Watch", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Game Boy", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Game Boy Advance", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Game Boy Color", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Gear VR", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Google Stadia", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Intellivision", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Interactive Movie", Category = "All Platforms" },
-            new HltbPlatform() { Name = "iOS", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Linux", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Mac", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Mobile", Category = "All Platforms" },
-            new HltbPlatform() { Name = "MSX", Category = "All Platforms" },
-            new HltbPlatform() { Name = "N-Gage", Category = "All Platforms" },
-            new HltbPlatform() { Name = "NEC PC-8800", Category = "All Platforms" },
-            new HltbPlatform() { Name = "NEC PC-9801/21", Category = "All Platforms" },
-            new HltbPlatform() { Name = "NEC PC-FX", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Neo Geo", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Neo Geo CD", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Neo Geo Pocket", Category = "All Platforms" },
-            new HltbPlatform() { Name = "NES", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Nintendo 3DS", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Nintendo 64", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Nintendo DS", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Nintendo GameCube", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Nintendo Switch", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Oculus Go", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Oculus Quest", Category = "All Platforms" },
-            new HltbPlatform() { Name = "OnLive", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Ouya", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PC", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PC VR", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Philips CD-i", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Philips Videopac G7000", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation 2", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation 3", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation 4", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation 5", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation Mobile", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation Now", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation Portable", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation Vita", Category = "All Platforms" },
-            new HltbPlatform() { Name = "PlayStation VR", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Plug & Play", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sega 32X", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sega CD", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sega Game Gear", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sega Master System", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sega Mega Drive/Genesis", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sega Saturn", Category = "All Platforms" },
-            new HltbPlatform() { Name = "SG-1000", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Sharp X68000", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Super Nintendo", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Tiger Handheld", Category = "All Platforms" },
-            new HltbPlatform() { Name = "TurboGrafx-16", Category = "All Platforms" },
-            new HltbPlatform() { Name = "TurboGrafx-CD", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Virtual Boy", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Wii", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Wii U", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Windows Phone", Category = "All Platforms" },
-            new HltbPlatform() { Name = "WonderSwan", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Xbox", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Xbox 360", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Xbox One", Category = "All Platforms" },
-            new HltbPlatform() { Name = "Xbox Series X/S", Category = "All Platforms" },
-            new HltbPlatform() { Name = "ZX Spectrum", Category = "All Platforms" }
-        };
 
 
         public HowLongToBeatDatabase(IPlayniteAPI PlayniteApi, HowLongToBeatSettingsViewModel PluginSettings, string PluginUserDataPath) : base(PlayniteApi, PluginSettings, "HowLongToBeat", PluginUserDataPath)
@@ -690,14 +599,17 @@ namespace HowLongToBeat.Services
                         TimeSpan time = TimeSpan.FromSeconds(game.Playtime + ElapsedSeconds);
 
                         // TODO Enough?
-                        string Platform = string.Empty;
-                        List<HltbPlatform> finded = hltbPlatforms.FindAll(x => game.Platforms?.FirstOrDefault().Name.Contains(x.Name, StringComparison.InvariantCultureIgnoreCase) ?? false);
-                        if (finded?.Count > 0)
-                        {
-                            Platform = finded.First().Name ?? string.Empty;
-                        }
-                        
-                        if (Platform.IsNullOrEmpty())
+                        string platform = game.Platforms?.FirstOrDefault().Name;
+                        /*int hltbMatches = platform == null ? 0 : HltbPlatforms.Values.Where(p => p.Name().Equals(platform)).Count();
+                        if (hltbMatches == 0) {
+                            platform = null;
+                            Guid gamePlatformGuid = game.PlatformIds.FirstOrDefault();
+                            if (PluginSettings.Settings.Platforms.ContainsKey(gamePlatformGuid)) {
+                                platform = PluginSettings.Settings.Platforms[gamePlatformGuid].Name();
+                            }
+                        }*/
+
+                        if (platform.IsNullOrEmpty())
                         {
                             logger.Warn($"No platform find for {game.Name}");
                         }
@@ -749,7 +661,7 @@ namespace HowLongToBeat.Services
                         hltbPostData.edit_id = edit_id;
                         hltbPostData.game_id = gameHowLongToBeat.GetData().Id;
                         hltbPostData.custom_title = gameHowLongToBeat.GetData().Name;
-                        hltbPostData.platform = Platform;
+                        hltbPostData.platform = platform;
                         hltbPostData.storefront = StorefrontName;
 
                         if (!NoPlaying)

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -19,6 +19,7 @@ using System.Windows.Threading;
 using FuzzySharp;
 using CommonPlayniteShared.Common;
 using CommonPluginsShared.Extensions;
+using System.Net;
 
 namespace HowLongToBeat.Services
 {
@@ -665,7 +666,7 @@ namespace HowLongToBeat.Services
                         hltbPostData.edit_id = edit_id;
                         hltbPostData.game_id = gameHowLongToBeat.GetData().Id;
                         hltbPostData.custom_title = gameHowLongToBeat.GetData().Name;
-                        hltbPostData.platform = platform;
+                        hltbPostData.platform = WebUtility.HtmlEncode(platform);
                         hltbPostData.storefront = StorefrontName;
 
                         if (!NoPlaying)

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -599,15 +599,19 @@ namespace HowLongToBeat.Services
                         TimeSpan time = TimeSpan.FromSeconds(game.Playtime + ElapsedSeconds);
 
                         // TODO Enough?
-                        string platform = game.Platforms?.FirstOrDefault().Name;
-                        /*int hltbMatches = platform == null ? 0 : HltbPlatforms.Values.Where(p => p.Name().Equals(platform)).Count();
-                        if (hltbMatches == 0) {
-                            platform = null;
-                            Guid gamePlatformGuid = game.PlatformIds.FirstOrDefault();
-                            if (PluginSettings.Settings.Platforms.ContainsKey(gamePlatformGuid)) {
-                                platform = PluginSettings.Settings.Platforms[gamePlatformGuid].Name();
-                            }
-                        }*/
+                        string platform = string.Empty;
+                        Platform gamePlatform = game.Platforms?.FirstOrDefault();
+                        if (gamePlatform == default(Platform)) {
+                            logger.Warn($"Cannot submit data for a game without platform ({game.Name})");
+                            return false;
+                        }
+                        HltbPlatform? match = PluginSettings.Settings.Platforms
+                                .Where(p => p.Platform == gamePlatform).FirstOrDefault()?.HltbPlatform;
+                        if (match != null) {
+                            platform = match.GetDescription();
+                        } else {
+                            platform = gamePlatform.Name;
+                        }
 
                         if (platform.IsNullOrEmpty())
                         {

--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -112,7 +112,7 @@
                 <TextBlock Grid.Column="0" Text="{DynamicResource LOCPlatformsTitle}" Style="{StaticResource BaseTextBlockStyle}" 
                            VerticalAlignment="Center" />
                 <controls:ComboBoxRemovable x:Name="PART_SelectPlatform" Grid.Column="2" VerticalAlignment="Center"
-                                            IsEditable="True" TextSearch.TextPath="GetDescription"
+                                            IsEditable="True" TextSearch.TextPath="DisplayText"
                                             IsTextSearchCaseSensitive="False" StaysOpenOnEdit="True"
                                             hltb:SelectorBehaviors.EnumSource="{x:Type hltm:HltbPlatform}">
                 </controls:ComboBoxRemovable>

--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -8,6 +8,8 @@
              xmlns:converters="clr-namespace:CommonPlayniteShared.Converters"
              xmlns:controls="clr-namespace:CommonPluginsControls.Controls"
              xmlns:convertersshared="clr-namespace:CommonPluginsShared.Converters"
+             xmlns:hltm="clr-namespace:HowLongToBeat.Models"
+             xmlns:hltb="clr-namespace:HowLongToBeat.Behaviors"
              mc:Ignorable="d" Width="500" Height="470">
 
     <UserControl.Resources>
@@ -105,16 +107,14 @@
                     <ColumnDefinition Width="150" />
                 </Grid.ColumnDefinitions>
 
+
+
                 <TextBlock Grid.Column="0" Text="{DynamicResource LOCPlatformsTitle}" Style="{StaticResource BaseTextBlockStyle}" 
                            VerticalAlignment="Center" />
                 <controls:ComboBoxRemovable x:Name="PART_SelectPlatform" Grid.Column="2" VerticalAlignment="Center"
-                                            IsEditable="True" TextSearch.TextPath="Name"
-                                            IsTextSearchCaseSensitive="False" StaysOpenOnEdit="True">
-                    <ComboBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding Name}" />
-                        </DataTemplate>
-                    </ComboBox.ItemTemplate>
+                                            IsEditable="True" TextSearch.TextPath="GetDescription"
+                                            IsTextSearchCaseSensitive="False" StaysOpenOnEdit="True"
+                                            hltb:SelectorBehaviors.EnumSource="{x:Type hltm:HltbPlatform}">
                 </controls:ComboBoxRemovable>
             </Grid>
 

--- a/source/Views/HowLongToBeatSelect.xaml.cs
+++ b/source/Views/HowLongToBeatSelect.xaml.cs
@@ -29,10 +29,8 @@ namespace HowLongToBeat.Views
         public HowLongToBeatSelect(List<HltbData> data, Game game)
         {
             _game = game;
-
+            
             InitializeComponent();
-
-            SetPlatforms();
 
             SearchElement.Text = PlayniteTools.NormalizeGameName(_game.Name);
 
@@ -51,13 +49,6 @@ namespace HowLongToBeat.Views
             // Set Binding data
             DataContext = this;
         }
-
-
-        private void SetPlatforms()
-        {
-            PART_SelectPlatform.ItemsSource = HowLongToBeat.PluginDatabase.hltbPlatforms;
-        }
-
 
         private void ButtonCancel_Click(object sender, RoutedEventArgs e)
         {
@@ -105,9 +96,10 @@ namespace HowLongToBeat.Views
 
             PART_DataLoadWishlist.Visibility = Visibility.Visible;
             SelectableContent.IsEnabled = false;
-
+            
             string GameSearch = SearchElement.Text;
-            string GamePlatform = ((HltbPlatform)PART_SelectPlatform.SelectedValue == null) ? string.Empty : ((HltbPlatform)PART_SelectPlatform.SelectedValue).Name;
+            string GamePlatform = (PART_SelectPlatform.SelectedValue == null) 
+                  ? string.Empty : ((HltbPlatform) PART_SelectPlatform.SelectedValue).GetDescription();
             Task task = Task.Run(() =>
             {
                 List<HltbDataUser> dataSearch = new List<HltbDataUser>();
@@ -182,11 +174,4 @@ namespace HowLongToBeat.Views
         }
     }
 
-
-
-    public class HltbPlatform
-    {
-        public string Name { get; set; }
-        public string Category { get; set; }
-    }
 }

--- a/source/Views/HowLongToBeatSettingsView.xaml
+++ b/source/Views/HowLongToBeatSettingsView.xaml
@@ -6,6 +6,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="clr-namespace:CommonPluginsControls.Controls"
              xmlns:HowLongToBeat="clr-namespace:HowLongToBeat"
+             xmlns:hltm="clr-namespace:HowLongToBeat.Models"
              mc:Ignorable="d" d:DesignWidth="650"
              d:DataContext="{d:DesignInstance HowLongToBeat:HowLongToBeatSettingsViewModel}">
 
@@ -302,7 +303,7 @@
                                     <RowDefinition Height="10" />
                                     <RowDefinition Height="auto" />
                                 </Grid.RowDefinitions>
-                                
+
                                 <Expander Grid.Row="2" AttachedProperties:ExpanderAttachedProperties.HideExpanderArrow="True">
                                     <Expander.Style>
                                         <Style TargetType="{x:Type Expander}" BasedOn="{StaticResource {x:Type Expander}}">
@@ -472,6 +473,61 @@
             </ScrollViewer>
         </TabItem>
 
+        <TabItem Header="{DynamicResource LOCPlatformsTitle}" IsEnabled="True">
+            <ScrollViewer Margin="0,10,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="63*"/>
+                        <ColumnDefinition Width="85*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0" MinHeight="100" Grid.ColumnSpan="2" Margin="0,0,-0.001,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="10" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Name="PART_GridPlatforms" Grid.Row="2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="45*"/>
+                                <ColumnDefinition Width="547*"/>
+                            </Grid.ColumnDefinitions>
+                            <ListBox Height="{Binding ElementName=PART_GridPlatforms, Path=ActualHeight}"
+                                     Name="PART_GridPlatformsList" Grid.ColumnSpan="2" Margin="0,0,-0.001,-0.001">
+                                <ListBox.ItemContainerStyle>
+                                    <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                                        <Setter Property="Focusable" Value="False"/>
+                                    </Style>
+                                </ListBox.ItemContainerStyle>
+
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="0,2">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="200" />
+                                                <ColumnDefinition Width="10" />
+                                                <ColumnDefinition Width="250" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBlock Grid.Column="0" Text="{Binding Platform}" />
+
+                                            <ComboBox Grid.Column="2" ItemsSource="{Binding HltbPlatformList}"
+                                                  SelectedValuePath="Id" DisplayMemberPath="Name"
+                                                  SelectedValue="{Binding HltbPlatform}" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </ScrollViewer>
+        </TabItem>
+
         <TabItem Header="{DynamicResource LOCMenuConfigurationTitle}" 
                  IsEnabled="{Binding ElementName=PART_AutoSetCurrentPlayTime, Path=IsChecked}">
             <ScrollViewer Margin="0,10,0,0">
@@ -493,8 +549,12 @@
                         </StackPanel>
 
                         <Grid Name="PART_GridStorefront" Grid.Row="2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="45*"/>
+                                <ColumnDefinition Width="547*"/>
+                            </Grid.ColumnDefinitions>
                             <ListBox Height="{Binding ElementName=PART_GridStorefront, Path=ActualHeight}"
-                                     ItemsSource="{Binding Settings.Storefronts}">
+                                     ItemsSource="{Binding Settings.Storefronts}" Grid.ColumnSpan="2" Margin="0,0,-0.001,-0.001">
                                 <ListBox.ItemContainerStyle>
                                     <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
                                         <Setter Property="Focusable" Value="False"/>

--- a/source/Views/HowLongToBeatSettingsView.xaml
+++ b/source/Views/HowLongToBeatSettingsView.xaml
@@ -7,6 +7,7 @@
              xmlns:controls="clr-namespace:CommonPluginsControls.Controls"
              xmlns:HowLongToBeat="clr-namespace:HowLongToBeat"
              xmlns:hltm="clr-namespace:HowLongToBeat.Models"
+             xmlns:hltb="clr-namespace:HowLongToBeat.Behaviors"
              mc:Ignorable="d" d:DesignWidth="650"
              d:DataContext="{d:DesignInstance HowLongToBeat:HowLongToBeatSettingsViewModel}">
 
@@ -515,8 +516,8 @@
 
                                             <TextBlock Grid.Column="0" Text="{Binding Platform}" />
 
-                                            <ComboBox Grid.Column="2" ItemsSource="{Binding HltbPlatformList}"
-                                                  SelectedValuePath="Id" DisplayMemberPath="Name"
+                                            <ComboBox Grid.Column="2"
+                                                  hltb:SelectorBehaviors.EnumSource="{x:Type hltm:HltbPlatform}"
                                                   SelectedValue="{Binding HltbPlatform}" />
                                         </Grid>
                                     </DataTemplate>

--- a/source/Views/HowLongToBeatSettingsView.xaml.cs
+++ b/source/Views/HowLongToBeatSettingsView.xaml.cs
@@ -45,9 +45,6 @@ namespace HowLongToBeat.Views
         public static SolidColorBrush ThirdMultiColorBrush;
         public static ThemeLinearGradient ThirdMultiLinearGradient;
 
-        public static List<HltbPlatformMatch> PlatformMatches = new List<HltbPlatformMatch>();
-
-
         public HowLongToBeatSettingsView(IPlayniteAPI PlayniteApi, string PluginUserDataPath, HowLongToBeatSettings settings)
         {
             _PlayniteApi = PlayniteApi;
@@ -437,6 +434,7 @@ namespace HowLongToBeat.Views
                     .ForEach(p => settings.Platforms.Add(
                             new HltbPlatformMatch { Platform = p }));
 
+            settings.Platforms.Sort();
             PART_GridPlatformsList.ItemsSource = settings.Platforms;
         }
 

--- a/source/Views/HowLongToBeatSettingsView.xaml.cs
+++ b/source/Views/HowLongToBeatSettingsView.xaml.cs
@@ -11,6 +11,8 @@ using HowLongToBeat.Models;
 using CommonPluginsShared.Models;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Collections.Generic;
+using Playnite.SDK.Models;
 
 namespace HowLongToBeat.Views
 {
@@ -43,6 +45,8 @@ namespace HowLongToBeat.Views
         public static SolidColorBrush ThirdMultiColorBrush;
         public static ThemeLinearGradient ThirdMultiLinearGradient;
 
+        public static List<HltbPlatformMatch> PlatformMatches = new List<HltbPlatformMatch>();
+
 
         public HowLongToBeatSettingsView(IPlayniteAPI PlayniteApi, string PluginUserDataPath, HowLongToBeatSettings settings)
         {
@@ -52,6 +56,8 @@ namespace HowLongToBeat.Views
             InitializeComponent();
 
             CheckAuthenticate();
+
+            SetPlatforms(settings);
 
             PART_SelectorColorPicker.OnlySimpleColor = false;
 
@@ -422,6 +428,18 @@ namespace HowLongToBeat.Views
         #endregion
 
 
+        private void SetPlatforms(HowLongToBeatSettings settings) {
+            List<Platform> platforms = PluginDatabase.PlayniteApi.Database
+                    .Platforms.Distinct().OrderBy(x => x.Name).ToList();
+
+            settings.Platforms.RemoveAll(m => !platforms.Contains(m.Platform));
+            platforms.Where(p => settings.Platforms.Exists(m => m.Platform == p))
+                    .ForEach(p => settings.Platforms.Add(
+                            new HltbPlatformMatch { Platform = p }));
+                    
+            PART_GridPlatformsList.ItemsSource = settings.Platforms;
+        }
+
         private void CbDefaultSorting_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             string index = ((ComboBoxItem)cbDefaultSorting.SelectedItem).Tag.ToString();
@@ -445,4 +463,5 @@ namespace HowLongToBeat.Views
             }
         }
     }
+
 }

--- a/source/Views/HowLongToBeatSettingsView.xaml.cs
+++ b/source/Views/HowLongToBeatSettingsView.xaml.cs
@@ -424,15 +424,20 @@ namespace HowLongToBeat.Views
         }
         #endregion
 
-
+        // TODO: Probably better to react to library metadata edits
+        // Although this method might not be invoked so many times as to make a difference in performance
         private void SetPlatforms(HowLongToBeatSettings settings) {
             List<Platform> platforms = PluginDatabase.PlayniteApi.Database
                     .Platforms.Distinct().OrderBy(x => x.Name).ToList();
 
+            // Remove from settings game platforms that were deleted
             settings.Platforms.RemoveAll(m => !platforms.Contains(m.Platform));
-            platforms.Where(p => !settings.Platforms.Exists(m => m.Platform.Equals(p)))
-                    .ForEach(p => settings.Platforms.Add(
-                            new HltbPlatformMatch { Platform = p }));
+            // Add an empty match for game platforms not in the settings
+            platforms.Where(p => !settings.Platforms.Exists(m => p.Equals(m.Platform)))
+                    .ForEach(p => settings.Platforms.Add(new HltbPlatformMatch { Platform = p }));
+            // Replace game platform in settings where GUID matches to actualize names
+            platforms.ForEach(p => settings.Platforms.Where(m => p.Equals(m.Platform))
+                    .ForEach(m => m.Platform = p));
 
             settings.Platforms.Sort();
             PART_GridPlatformsList.ItemsSource = settings.Platforms;

--- a/source/Views/HowLongToBeatSettingsView.xaml.cs
+++ b/source/Views/HowLongToBeatSettingsView.xaml.cs
@@ -430,7 +430,7 @@ namespace HowLongToBeat.Views
                     .Platforms.Distinct().OrderBy(x => x.Name).ToList();
 
             settings.Platforms.RemoveAll(m => !platforms.Contains(m.Platform));
-            platforms.Where(p => !settings.Platforms.Exists(m => m.Platform == p))
+            platforms.Where(p => !settings.Platforms.Exists(m => m.Platform.Equals(p)))
                     .ForEach(p => settings.Platforms.Add(
                             new HltbPlatformMatch { Platform = p }));
 

--- a/source/Views/HowLongToBeatSettingsView.xaml.cs
+++ b/source/Views/HowLongToBeatSettingsView.xaml.cs
@@ -433,10 +433,10 @@ namespace HowLongToBeat.Views
                     .Platforms.Distinct().OrderBy(x => x.Name).ToList();
 
             settings.Platforms.RemoveAll(m => !platforms.Contains(m.Platform));
-            platforms.Where(p => settings.Platforms.Exists(m => m.Platform == p))
+            platforms.Where(p => !settings.Platforms.Exists(m => m.Platform == p))
                     .ForEach(p => settings.Platforms.Add(
                             new HltbPlatformMatch { Platform = p }));
-                    
+
             PART_GridPlatformsList.ItemsSource = settings.Platforms;
         }
 


### PR DESCRIPTION
https://github.com/Lacro59/playnite-howlongtobeat-plugin/issues/158

Users are now able to tell the plugin what HLTB platform matches with their Playnite platform. Before, time submission would fail if Playnite's platform wasn't named exactly like an HLTB platform. Now, it is possible to have games markes as "Famicom" in Playnite and have their time submitted as "NES" on HLTB to conform to their recommended list of platforms.

In addition, I've fixed a bug where platform strings where not correctly submitted due to lack of URL encoding of their values.