### PR TITLE
FIX #240 - Allows Search functionality to work again after website changes

### DIFF
--- a/source/Services/HowLongToBeatClient.cs
+++ b/source/Services/HowLongToBeatClient.cs
@@ -206,7 +206,7 @@ namespace HowLongToBeat.Services
 
             try
             {
-                string url = string.Format(UrlSearchWeb, "toto");
+                string url = UrlBase;
                 string response = await Web.DownloadStringData(url);
 
                 string js = Regex.Match(response, @"_app-\w*.js").Value;
@@ -214,7 +214,8 @@ namespace HowLongToBeat.Services
                 {
                     url = $"https://howlongtobeat.com/_next/static/chunks/pages/{js}";
                     response = await Web.DownloadStringData(url);
-                    SearchId = Regex.Match(response, "\"/api/search/\".concat[(]\"(\\w*)\"[)]").Groups[1].Value;
+                    Match matches= Regex.Match(response, "\"/api/search/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
+                    SearchId = matches.Groups[1].Value + matches.Groups[2].Value;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Some recent website changes seem to have affected the Search functionality. 

A couple of changes are included in the fix:
- UrlSearchWeb request was hitting a redirect where the js string could not be found anymore. UrlBase was however containing the string we were after, so the latter was used instead.
- The js string then contained two concats instead of one, so the regexp was updated accordingly.

This change has been tested successfully by a few users from the hotfix release made from this branch.