### PR TITLE
Fixed #227 by removing superfluous checks on gameHowLongToBeat data values

### DIFF
--- a/source/Views/HowLongToBeatView.xaml.cs
+++ b/source/Views/HowLongToBeatView.xaml.cs
@@ -16,6 +16,7 @@ using CommonPluginsShared;
 using CommonPluginsShared.Converters;
 using System.Globalization;
 using CommonPluginsShared.Extensions;
+using Playnite.SDK.Data;
 
 namespace HowLongToBeat.Views
 {
@@ -90,7 +91,7 @@ namespace HowLongToBeat.Views
                 return;
             }
 
-            if (gameHowLongToBeat.HasData)
+            if (gameData != null)
             {
                 ((HowLongToBeatViewData)DataContext).CoverImage = gameData.UrlImg;
 
@@ -118,7 +119,7 @@ namespace HowLongToBeat.Views
                 PART_TextBlock.Visibility = Visibility.Hidden;
             }
 
-            if (gameHowLongToBeat.HasData)
+            if (gameData != null)
             {
                 Hltb_El1.Visibility = Visibility.Hidden;
                 Hltb_El1_Color.Visibility = Visibility.Hidden;
@@ -126,6 +127,7 @@ namespace HowLongToBeat.Views
                 Hltb_El2_Color.Visibility = Visibility.Hidden;
                 Hltb_El3.Visibility = Visibility.Hidden;
                 Hltb_El3_Color.Visibility = Visibility.Hidden;
+
 
                 List<TitleList> titleLists = PluginDatabase.GetUserHltbDataAll(gameHowLongToBeat.GetData().Id);
                 TitleList titleList = null;
@@ -182,47 +184,29 @@ namespace HowLongToBeat.Views
 
                         if (gameData.GameType != GameType.Multi)
                         {
-                            if (gameData.GameHltbData.MainStory != 0 || titleList.HltbUserData?.MainStory != 0)
-                            {
-                                ElIndicator += 1;
-                                SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainStory"), gameData.GameHltbData.MainStoryFormat, (titleList != null) ? titleList.HltbUserData.MainStoryFormat : string.Empty, idx);
-                                SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirst.Color);
-                            }
+                            ElIndicator += 1;
+                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainStory"), gameData.GameHltbData.MainStoryFormat, (titleList != null) ? titleList.HltbUserData.MainStoryFormat : string.Empty, idx);
+                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirst.Color);
 
-                            if (gameData.GameHltbData.MainExtra != 0 || titleList.HltbUserData?.MainExtra != 0)
-                            {
-                                ElIndicator += 1;
-                                SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainExtra"), gameData.GameHltbData.MainExtraFormat, (titleList != null) ? titleList.HltbUserData.MainExtraFormat : string.Empty, idx);
-                                SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorSecond.Color);
-                            }
+                            ElIndicator += 1;
+                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainExtra"), gameData.GameHltbData.MainExtraFormat, (titleList != null) ? titleList.HltbUserData.MainExtraFormat : string.Empty, idx);
+                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorSecond.Color);
 
-                            if (gameData.GameHltbData.Completionist != 0 || titleList.HltbUserData?.Completionist != 0)
-                            {
-                                ElIndicator += 1;
-                                SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCompletionist"), gameData.GameHltbData.CompletionistFormat, (titleList != null) ? titleList.HltbUserData.CompletionistFormat : string.Empty, idx);
-                                SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorThird.Color);
-                            }
+                            ElIndicator += 1;
+                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCompletionist"), gameData.GameHltbData.CompletionistFormat, (titleList != null) ? titleList.HltbUserData.CompletionistFormat : string.Empty, idx);
+                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorThird.Color);
                         }
                         else
                         {
-                            if (gameData.GameHltbData.Solo != 0 || titleList.HltbUserData?.Solo != 0)
-                            {
-                                ElIndicator += 1;
-                                SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatSolo"), gameData.GameHltbData.SoloFormat, (titleList != null) ? titleList.HltbUserData.SoloFormat : string.Empty, idx);
-                                SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirstMulti.Color);
-                            }
+                            ElIndicator += 1;
+                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatSolo"), gameData.GameHltbData.SoloFormat, (titleList != null) ? titleList.HltbUserData.SoloFormat : string.Empty, idx);
+                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirstMulti.Color);
 
-                            if (gameData.GameHltbData.CoOp != 0 || titleList.HltbUserData?.CoOp != 0)
-                            {
-                                ElIndicator += 1;
-                                SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCoOp"), gameData.GameHltbData.CoOpFormat, (titleList != null) ? titleList.HltbUserData.CoOpFormat : string.Empty, idx);
-                            }
+                            ElIndicator += 1;
+                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCoOp"), gameData.GameHltbData.CoOpFormat, (titleList != null) ? titleList.HltbUserData.CoOpFormat : string.Empty, idx);
 
-                            if (gameData.GameHltbData.Vs != 0 || titleList.HltbUserData?.Vs != 0)
-                            {
-                                ElIndicator += 1;
-                                SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatVs"), gameData.GameHltbData.VsFormat, (titleList != null) ? titleList.HltbUserData.VsFormat : string.Empty, idx);
-                            }
+                            ElIndicator += 1;
+                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatVs"), gameData.GameHltbData.VsFormat, (titleList != null) ? titleList.HltbUserData.VsFormat : string.Empty, idx);
                         }
                     }
                 }
@@ -233,47 +217,29 @@ namespace HowLongToBeat.Views
 
                     if (gameData.GameType != GameType.Multi)
                     {
-                        if (gameData.GameHltbData.MainStory != 0)
-                        {
-                            ElIndicator += 1;
-                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainStory"), gameData.GameHltbData.MainStoryFormat, (titleList != null) ? titleList.HltbUserData.MainStoryFormat : string.Empty, 0);
-                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirst.Color);
-                        }
+                        ElIndicator += 1;
+                        SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainStory"), gameData.GameHltbData.MainStoryFormat, (titleList != null) ? titleList.HltbUserData.MainStoryFormat : string.Empty, 0);
+                        SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirst.Color);
 
-                        if (gameData.GameHltbData.MainExtra != 0)
-                        {
-                            ElIndicator += 1;
-                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainExtra"), gameData.GameHltbData.MainExtraFormat, (titleList != null) ? titleList.HltbUserData.MainExtraFormat : string.Empty, 0);
-                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorSecond.Color);
-                        }
+                        ElIndicator += 1;
+                        SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatMainExtra"), gameData.GameHltbData.MainExtraFormat, (titleList != null) ? titleList.HltbUserData.MainExtraFormat : string.Empty, 0);
+                        SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorSecond.Color);
 
-                        if (gameData.GameHltbData.Completionist != 0)
-                        {
-                            ElIndicator += 1;
-                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCompletionist"), gameData.GameHltbData.CompletionistFormat, (titleList != null) ? titleList.HltbUserData.CompletionistFormat : string.Empty, 0);
-                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorThird.Color);
-                        }
+                        ElIndicator += 1;
+                        SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCompletionist"), gameData.GameHltbData.CompletionistFormat, (titleList != null) ? titleList.HltbUserData.CompletionistFormat : string.Empty, 0);
+                        SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorThird.Color);
                     }
                     else
                     {
-                        if (gameData.GameHltbData.Solo != 0)
-                        {
-                            ElIndicator += 1;
-                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatSolo"), gameData.GameHltbData.SoloFormat, (titleList != null) ? titleList.HltbUserData.SoloFormat : string.Empty, 0);
-                            SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirstMulti.Color);
-                        }
+                        ElIndicator += 1;
+                        SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatSolo"), gameData.GameHltbData.SoloFormat, (titleList != null) ? titleList.HltbUserData.SoloFormat : string.Empty, 0);
+                        SetColor(ElIndicator, PluginDatabase.PluginSettings.Settings.ColorFirstMulti.Color);
 
-                        if (gameData.GameHltbData.CoOp != 0)
-                        {
-                            ElIndicator += 1;
-                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCoOp"), gameData.GameHltbData.CoOpFormat, (titleList != null) ? titleList.HltbUserData.CoOpFormat : string.Empty, 0);
-                        }
+                        ElIndicator += 1;
+                        SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatCoOp"), gameData.GameHltbData.CoOpFormat, (titleList != null) ? titleList.HltbUserData.CoOpFormat : string.Empty, 0);
 
-                        if (gameData.GameHltbData.Vs != 0)
-                        {
-                            ElIndicator += 1;
-                            SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatVs"), gameData.GameHltbData.VsFormat, (titleList != null) ? titleList.HltbUserData.VsFormat : string.Empty, 0);
-                        }
+                        ElIndicator += 1;
+                        SetDataInView(ElIndicator, ResourceProvider.GetString("LOCHowLongToBeatVs"), gameData.GameHltbData.VsFormat, (titleList != null) ? titleList.HltbUserData.VsFormat : string.Empty, 0);
                     }
                 }
 


### PR DESCRIPTION
As long as gameData is not null, data can safely be set in view as originally coded, even with GameHltbData sections values set to 0.The progress section is kept hidden though, as there is no data comparison possible with user playtime.
The theme integration widget remains empty, but clicking the plugin button now shows the game name properly with its cover image and refresh/delete functionalities work again without throwing exceptions anymore.