### PR TITLE
Fixed #235 - Truncated display in HowLongToBeatSelect view

### DIFF
--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -11,7 +11,7 @@
     xmlns:hltm="clr-namespace:HowLongToBeat.Models"
     xmlns:hltb="clr-namespace:HowLongToBeat.Behaviors" 
     xmlns:controls1="clr-namespace:CommonPluginsShared.Controls"
-    mc:Ignorable="d" Width="700" Height="600">
+    mc:Ignorable="d" Width="700">
 
     <UserControl.Resources>
         <convertersshared:VisibilityZeroConverter x:Key="VisibilityZeroConverter" />


### PR DESCRIPTION
Removing height constraint on UserControl allows for automatic size adjustment.
This change has been tested on the following themes: Stardust, Nova X, Helium.