### PR TITLE
Fixing the search lookup

### DIFF
--- a/source/Services/HowLongToBeatClient.cs
+++ b/source/Services/HowLongToBeatClient.cs
@@ -71,7 +71,7 @@ namespace HowLongToBeat.Services
 
         private static string UrlPostData => UrlBase + "/api/submit";
         private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
-        private static string UrlSearch => UrlBase + "/api/lookup";
+        private static string UrlSearch => UrlBase + "/api/s";
 
         private static string UrlGameImg => UrlBase + "/games/{0}";
 
@@ -219,7 +219,7 @@ namespace HowLongToBeat.Services
                 {
                     url += $"/_next/static/chunks/pages/{js}";
                     response = await Web.DownloadStringData(url);
-                    Match matches = Regex.Match(response, "\"/api/lookup/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
+                    Match matches = Regex.Match(response, "\"/api/s/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
                     SearchId = matches.Groups[1].Value + matches.Groups[2].Value;
                 }
             }


### PR DESCRIPTION
The search lookup has changed from "/api/lookup/" to "/api/s/". Changed the variables used in the search and the regex when checking the js file. This has allowed the search to populate and gives you a successful response when hit.

Testing postman:
![image](https://github.com/user-attachments/assets/d8c9a908-0be8-4a88-8070-ed31f834ec39)

Also stepped through the code and viewed it grabbing a successful request:
Showing the URL change:
![Screenshot 2025-01-19 193119](https://github.com/user-attachments/assets/9c88b93c-0c49-43b6-9faa-7e8cc1b9d7d3)

Success when hitting the new url:
![devenv_xJ0MNxyq0B](https://github.com/user-attachments/assets/6b1898d5-b4ea-4209-a5c6-90ab18e99941)
