### PR TITLE
search api updated

### DIFF
--- a/source/Services/HowLongToBeatClient.cs
+++ b/source/Services/HowLongToBeatClient.cs
@@ -71,7 +71,7 @@ namespace HowLongToBeat.Services
 
         private static string UrlPostData => UrlBase + "/api/submit";
         private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
-        private static string UrlSearch => UrlBase + "/api/s";
+        private static string UrlSearch => UrlBase + "/api/ouch";
 
         private static string UrlGameImg => UrlBase + "/games/{0}";
 
@@ -219,7 +219,7 @@ namespace HowLongToBeat.Services
                 {
                     url += $"/_next/static/chunks/pages/{js}";
                     response = await Web.DownloadStringData(url);
-                    Match matches = Regex.Match(response, "\"/api/s/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
+                    Match matches = Regex.Match(response, "\"/api/ouch/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
                     SearchId = matches.Groups[1].Value + matches.Groups[2].Value;
                 }
             }


### PR DESCRIPTION
Search API updated from "api/s" to "api/ouch". Have tested that this is working and get see 200 responses in Postman and also within Playnite

Postman response
![image](https://github.com/user-attachments/assets/203e8982-e13d-4ba8-a13b-939c85a6bdb7)

Getting the expected SearchId when checking for "api/ouch"
![image](https://github.com/user-attachments/assets/161849e8-428c-4615-93fa-8fc501b6db45)

Successful response when searching
![image](https://github.com/user-attachments/assets/94989db8-587a-4d47-a906-2b60ff66efae)
