### PR TITLE
Update HowLongToBeatApi.cs

### DIFF
--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -83,9 +83,9 @@ namespace HowLongToBeat.Services
 
             // TEMP
             FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.json"));
-            FileSystem.DeleteFileSafe(FileCookies);
+            //FileSystem.DeleteFileSafe(FileCookies);
 
-            FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.dat"));
+            //FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.dat"));
         }
 
 


### PR DESCRIPTION
To fix bug that disallows users from syncing their progress using playnite extension, mentioned in #278  