### PR TITLE
Fix using a disposed WebView in GetWebCookies()

### DIFF
--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -824,35 +824,36 @@ namespace HowLongToBeat.Services
         internal virtual List<HttpCookie> GetWebCookies(IWebView webView = null, bool deleteCookies = true)
         {
             List<HttpCookie> httpCookies = new List<HttpCookie>();
+			var createWebView = webView == null;
 
-            try
-            {
-                if (webView == null)
-                {
-                    using (webView = API.Instance.WebViews.CreateOffscreenView())
-                    {
-                        httpCookies = webView?.GetCookies()?
-                            .Where(x => x?.Domain?.Contains("howlongtobeat") ?? false)?
-                            .ToList() ?? new List<HttpCookie>();
-                    }
-                }
-                else
-                {
-                    httpCookies = webView.GetCookies()?
-                        .Where(x => x?.Domain?.Contains("howlongtobeat") ?? false)?
-                        .ToList() ?? new List<HttpCookie>();
-                }
+			try
+			{
+				if (createWebView)
+				{
+					webView = API.Instance.WebViews.CreateOffscreenView();
+				}
 
-                if (deleteCookies)
-                {
-                    webView.DeleteDomainCookies("howlongtobeat.com");
-                    webView.DeleteDomainCookies(".howlongtobeat.com");
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, "HowLongToBeat");
-            }
+				httpCookies = webView.GetCookies()?
+					.Where(x => x?.Domain?.Contains("howlongtobeat") ?? false)?
+					.ToList() ?? new List<HttpCookie>();
+
+				if (deleteCookies)
+				{
+					webView.DeleteDomainCookies("howlongtobeat.com");
+					webView.DeleteDomainCookies(".howlongtobeat.com");
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, "HowLongToBeat");
+			}
+			finally
+			{
+				if (createWebView)
+				{
+                    webView?.Dispose();
+				}
+			}
 
             return httpCookies;
         }

--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -824,36 +824,36 @@ namespace HowLongToBeat.Services
         internal virtual List<HttpCookie> GetWebCookies(IWebView webView = null, bool deleteCookies = true)
         {
             List<HttpCookie> httpCookies = new List<HttpCookie>();
-			var createWebView = webView == null;
+            var createWebView = webView == null;
 
-			try
-			{
-				if (createWebView)
-				{
-					webView = API.Instance.WebViews.CreateOffscreenView();
-				}
+            try
+            {
+                if (createWebView)
+                {
+                    webView = API.Instance.WebViews.CreateOffscreenView();
+                }
 
-				httpCookies = webView.GetCookies()?
-					.Where(x => x?.Domain?.Contains("howlongtobeat") ?? false)?
-					.ToList() ?? new List<HttpCookie>();
+                httpCookies = webView.GetCookies()?
+                    .Where(x => x?.Domain?.Contains("howlongtobeat") ?? false)?
+                    .ToList() ?? new List<HttpCookie>();
 
-				if (deleteCookies)
-				{
-					webView.DeleteDomainCookies("howlongtobeat.com");
-					webView.DeleteDomainCookies(".howlongtobeat.com");
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, "HowLongToBeat");
-			}
-			finally
-			{
-				if (createWebView)
-				{
+                if (deleteCookies)
+                {
+                    webView.DeleteDomainCookies("howlongtobeat.com");
+                    webView.DeleteDomainCookies(".howlongtobeat.com");
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, "HowLongToBeat");
+            }
+            finally
+            {
+                if (createWebView)
+                {
                     webView?.Dispose();
-				}
-			}
+                }
+            }
 
             return httpCookies;
         }


### PR DESCRIPTION
Originally the code is trying to access a disposed WebView to delete cookies. Fixed it to only dispose after the method has been executed in a `finally` block.

This should hopefully fix #283
I have not built/tested the code myself, since it's very difficult to build.