### PR TITLE
Fix HLTB search not working

### DIFF
--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -55,7 +55,8 @@ namespace HowLongToBeat.Services
 
         private static string UrlPostData => UrlBase + "/api/submit";
         private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
-        private static string UrlSearch => UrlBase + "/api/seek";
+        private static string SearchEndPoint => "/api/locate";
+        private static string UrlSearch => UrlBase + SearchEndPoint;
 
         private static string UrlGameImg => UrlBase + "/games/{0}";
 
@@ -193,7 +194,7 @@ namespace HowLongToBeat.Services
                 {
                     url += $"/_next/static/chunks/pages/{js}";
                     response = await Web.DownloadStringData(url);
-                    Match matches = Regex.Match(response, "\"/api/seek/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
+                    Match matches = Regex.Match(response, $"\"{SearchEndPoint}/\".concat[(]\"(\\w*)\"[)].concat[(]\"(\\w*)\"[)]");
                     SearchId = matches.Groups[1].Value + matches.Groups[2].Value;
                 }
             }


### PR DESCRIPTION
Fix #296, they changed the API from /api/seek to /api/locate

<img width="917" height="676" alt="image" src="https://github.com/user-attachments/assets/d1594f3a-3208-4d29-b6b0-4f94b4d33f7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of game search and data retrieval by adapting to upstream API changes, reducing intermittent failures and timeouts.

* **Refactor**
  * Streamlined internal request construction and pattern matching to make the integration more resilient to minor backend changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->