### PR TITLE
Updated url for auth token

### DIFF
--- a/source/HowLongToBeat.cs
+++ b/source/HowLongToBeat.cs
@@ -39,7 +39,7 @@ namespace HowLongToBeat
         private bool PreventLibraryUpdatedOnStart { get; set; } = true;
 
 
-        public HowLongToBeat(IPlayniteAPI playniteAPI) : base(playniteAPI)
+        public HowLongToBeat(IPlayniteAPI playniteAPI) : base(playniteAPI, "HowLongToBeat")
         {
 
             // Custom theme button

--- a/source/HowLongToBeat.csproj
+++ b/source/HowLongToBeat.csproj
@@ -57,6 +57,9 @@
       <HintPath>packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Ardalis.GuardClauses, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Ardalis.GuardClauses.5.0.0\lib\netstandard2.0\Ardalis.GuardClauses.dll</HintPath>
+    </Reference>
     <Reference Include="FuzzySharp, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\FuzzySharp.2.0.2\lib\net461\FuzzySharp.dll</HintPath>
     </Reference>
@@ -69,9 +72,8 @@
     <Reference Include="LiveCharts.Wpf, Version=0.9.7.0, Culture=neutral, PublicKeyToken=0bc1f845d1ebb8df, processorArchitecture=MSIL">
       <HintPath>packages\LiveCharts.Wpf.0.9.7\lib\net45\LiveCharts.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Playnite.SDK, Version=6.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\PlayniteSDK.6.8.0\lib\net462\Playnite.SDK.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Playnite.SDK, Version=6.15.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.15.0\lib\net462\Playnite.SDK.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -565,6 +567,6 @@
   <Import Project="playnite-plugincommon\CommonPluginsShared\CommonPluginsShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -ExecutionPolicy Unrestricted $(SolutionDir)..\build\build.ps1 -ConfigurationName $(ConfigurationName) -OutDir $(SolutionDir)$(OutDir) -SolutionDir $(SolutionDir)</PostBuildEvent>
+    <PostBuildEvent>pwsh -ExecutionPolicy Unrestricted $(SolutionDir)..\build\build.ps1 -ConfigurationName $(ConfigurationName) -OutDir $(SolutionDir)$(OutDir) -SolutionDir $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -1078,7 +1078,7 @@ namespace HowLongToBeat.Services
         /// Retrieves the authentication token.
         /// </summary>
         /// <returns>The auth token.</returns>
-        private async Task<string> GetAuthToken()
+        private async Task<string> GetAuthToken(string apiEndpoint)
         {
             try
             {
@@ -1103,7 +1103,7 @@ namespace HowLongToBeat.Services
                 {
                     new HttpHeader { Key = "Referer", Value = UrlBase }
                 };
-                string url = UrlBase + "/api/finder/init?t=" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
                 string response = null;
                 try
                 {
@@ -1507,7 +1507,7 @@ namespace HowLongToBeat.Services
                 string serializedBody = Serialization.ToJson(searchParam);
                 string searchUrl = await GetSearchUrl();
                 bool tokenReused = !string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry;
-                string token = await GetAuthToken();
+                string token = await GetAuthToken(searchUrl);
                 if (!token.IsNullOrEmpty())
                 {
                     httpHeaders.Add(new HttpHeader { Key = "x-auth-token", Value = token });

--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -975,7 +975,7 @@ namespace HowLongToBeat.Services
                             if (!httpResp.IsSuccessStatusCode)
                             {
                                 try { Logger.Warn($"HTTP {(int)httpResp.StatusCode} downloading {url}"); } catch { }
-                                return "/api/search";
+                                return "/api/s";
                             }
 
                             response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -984,12 +984,12 @@ namespace HowLongToBeat.Services
                     catch (TaskCanceledException)
                     {
                         try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {url}"); } catch { }
-                        return "/api/search";
+                        return "/api/s";
                     }
                     catch (Exception ex)
                     {
                         Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                        return "/api/search";
+                        return "/api/s";
                     }
                 }
 
@@ -1071,7 +1071,7 @@ namespace HowLongToBeat.Services
                 Common.LogError(ex, false, true, PluginDatabase.PluginName);
             }
 
-            return "/api/search";
+            return "/api/s";
         }
 
         /// <summary>
@@ -1103,7 +1103,7 @@ namespace HowLongToBeat.Services
                 {
                     new HttpHeader { Key = "Referer", Value = UrlBase }
                 };
-                string url = UrlBase + "/api/search/init?t=" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                string url = UrlBase + "/api/finder/init?t=" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                 string response = null;
                 try
                 {

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -401,8 +401,13 @@ namespace HowLongToBeat.Services
             }
         }
 
-        public void RefreshNoLoader(Guid id)
+        public override void RefreshNoLoader(Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             Game game = API.Instance.Database.Games.Get(id);
             if (IsVerboseLoggingEnabled)
             {

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -401,7 +401,7 @@ namespace HowLongToBeat.Services
             }
         }
 
-        public override void RefreshNoLoader(Guid id)
+        public void RefreshNoLoader(Guid id)
         {
             Game game = API.Instance.Database.Games.Get(id);
             if (IsVerboseLoggingEnabled)

--- a/source/packages.config
+++ b/source/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
+  <package id="Ardalis.GuardClauses" version="5.0.0" targetFramework="net462" />
   <package id="FuzzySharp" version="2.0.2" targetFramework="net462" />
   <package id="HtmlAgilityPack" version="1.12.4" targetFramework="net48" />
   <package id="LiveCharts" version="0.9.7" targetFramework="net462" />
   <package id="LiveCharts.Wpf" version="0.9.7" targetFramework="net462" />
-  <package id="PlayniteSDK" version="6.8.0" targetFramework="net462" />
+  <package id="PlayniteSDK" version="6.15.0" targetFramework="net462" />
   <package id="StartPage.SDK" version="1.0.0" targetFramework="net462" />
   <package id="System.IO.Abstractions" version="2.1.0.227" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.6.1" targetFramework="net462" />


### PR DESCRIPTION
Fix auth token generation by passing actual search URL from [GetSearchUrl()](https://github.com/Lacro59/playnite-howlongtobeat-plugin/commit/f350adb40aca0b289e6f64d18cad3044bb1b2c76#diff-85262dda1e0b0e8a793133f1d5afe1f14ccee8fa97ac49d78fddf1593fd926a4L1510) into [GetAuthToken](https://github.com/Lacro59/playnite-howlongtobeat-plugin/commit/f350adb40aca0b289e6f64d18cad3044bb1b2c76#diff-85262dda1e0b0e8a793133f1d5afe1f14ccee8fa97ac49d78fddf1593fd926a4R1081), ensuring endpoint consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Playnite SDK to v6.15 and adjusted build pipeline to use PowerShell Core
  * Added a dependency to improve input validation and reliability

* **Improvements**
  * More robust data fetching and authentication handling with safer endpoint fallbacks
  * Added cancellation support for background refresh operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->