### PR TITLE
Manually add HLTB data

### DIFF
--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -135,6 +135,7 @@ If none has this status, it takes the most recent.</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatSetCurrentTime">Want you send your current playtime?</sys:String>
 
+    <sys:String x:Key="LOCHowLongToBeatErrorNoHltbId">Cannot submit data for a game without HLTB ID ({0})</sys:String>
     <sys:String x:Key="LOCHowLongToBeatErrorNoPlatform">Cannot submit data for a game without platform ({0})</sys:String>
     <sys:String x:Key="LOCHowLongToBeatErrorNoPlatformDefaultUsed" xml:space="preserve">Game ({1}) without platform ({0}) defined in plugin settings.
 Please configure one.

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -68,6 +68,7 @@ If none has this status, it takes the most recent.</sys:String>
     <sys:String x:Key="LOCHltbOpenOnWebsite">Search on HowLongToBeat</sys:String>
     <sys:String x:Key="LOCHltbManualEntryHours">h</sys:String>
     <sys:String x:Key="LOCHltbManualEntryMinutes">min</sys:String>
+    <sys:String x:Key="LOCHltbManualEntryHltbId">HLTB ID (optional)</sys:String>
     <sys:String x:Key="LOCHltbManualEntryConfirm">Use manual entry</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatMainStory">Main story</sys:String>

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -68,7 +68,7 @@ If none has this status, it takes the most recent.</sys:String>
     <sys:String x:Key="LOCHltbOpenOnWebsite">Search on HowLongToBeat</sys:String>
     <sys:String x:Key="LOCHltbManualEntryHours">h</sys:String>
     <sys:String x:Key="LOCHltbManualEntryMinutes">min</sys:String>
-    <sys:String x:Key="LOCHltbManualEntryHltbId">HLTB ID (optional)</sys:String>
+    <sys:String x:Key="LOCHltbManualEntryHltbId">HLTB ID</sys:String>
     <sys:String x:Key="LOCHltbManualEntryConfirm">Use manual entry</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatMainStory">Main story</sys:String>

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -63,6 +63,13 @@ If none has this status, it takes the most recent.</sys:String>
     <sys:String x:Key="LOCSelection">HowLongToBeat selection</sys:String>
     <sys:String x:Key="LOCHltbUsedVndb">Used Vndb</sys:String>
 
+    <sys:String x:Key="LOCHltbTabSearch">Search</sys:String>
+    <sys:String x:Key="LOCHltbTabManual">Enter manually</sys:String>
+    <sys:String x:Key="LOCHltbOpenOnWebsite">Search on HowLongToBeat</sys:String>
+    <sys:String x:Key="LOCHltbManualEntryHours">h</sys:String>
+    <sys:String x:Key="LOCHltbManualEntryMinutes">min</sys:String>
+    <sys:String x:Key="LOCHltbManualEntryConfirm">Use manual entry</sys:String>
+
     <sys:String x:Key="LOCHowLongToBeatMainStory">Main story</sys:String>
     <sys:String x:Key="LOCHowLongToBeatMainExtra">Main + extra</sys:String>
     <sys:String x:Key="LOCHowLongToBeatCompletionist">Completionist</sys:String>

--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -975,7 +975,7 @@ namespace HowLongToBeat.Services
                             if (!httpResp.IsSuccessStatusCode)
                             {
                                 try { Logger.Warn($"HTTP {(int)httpResp.StatusCode} downloading {url}"); } catch { }
-                                return "/api/search";
+                                return "/api/s";
                             }
 
                             response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
@@ -984,12 +984,12 @@ namespace HowLongToBeat.Services
                     catch (TaskCanceledException)
                     {
                         try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {url}"); } catch { }
-                        return "/api/search";
+                        return "/api/s";
                     }
                     catch (Exception ex)
                     {
                         Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                        return "/api/search";
+                        return "/api/s";
                     }
                 }
 
@@ -1071,14 +1071,15 @@ namespace HowLongToBeat.Services
                 Common.LogError(ex, false, true, PluginDatabase.PluginName);
             }
 
-            return "/api/search";
+            return "/api/s";
         }
 
-        /// <summary>
-        /// Retrieves the authentication token.
-        /// </summary>
-        /// <returns>The auth token.</returns>
-        private async Task<string> GetAuthToken()
+		/// <summary>
+		/// Retrieves the authentication token.
+		/// </summary>
+		/// <param name="apiEndpoint">API Endpoint for search</param>
+		/// <returns>The auth token.</returns>
+		private async Task<string> GetAuthToken(string apiEndpoint)
         {
             try
             {
@@ -1103,7 +1104,7 @@ namespace HowLongToBeat.Services
                 {
                     new HttpHeader { Key = "Referer", Value = UrlBase }
                 };
-                string url = UrlBase + "/api/search/init?t=" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
                 string response = null;
                 try
                 {
@@ -1507,7 +1508,7 @@ namespace HowLongToBeat.Services
                 string serializedBody = Serialization.ToJson(searchParam);
                 string searchUrl = await GetSearchUrl();
                 bool tokenReused = !string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry;
-                string token = await GetAuthToken();
+                string token = await GetAuthToken(searchUrl);
                 if (!token.IsNullOrEmpty())
                 {
                     httpHeaders.Add(new HttpHeader { Key = "x-auth-token", Value = token });

--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -25,2975 +25,3001 @@ using System.Windows;
 
 namespace HowLongToBeat.Services
 {
-    public partial class HowLongToBeatApi : ObservableObject, IDisposable
-    {
-        private static ILogger Logger => LogManager.GetLogger();
-
-        private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
-
-        // Helper to centralize verbose logging checks
-        private static bool IsVerboseLoggingEnabled => PluginDatabase?.PluginSettings?.Settings is HowLongToBeatSettings _vs && _vs.EnableVerboseLogging;
-
-        private void LogDebugVerbose(string message)
-        {
-            try
-            {
-                if (IsVerboseLoggingEnabled)
-                {
-                    Logger.Debug(message);
-                }
-            }
-            catch { }
-        }
-
-        private string SafeStr(string s)
-        {
-            try
-            {
-                if (s == null)
-                {
-                    return string.Empty;
-                }
-
-                s = s.Replace("\r", " ").Replace("\n", " ");
-                return s.Length > 120 ? s.Substring(0, 120) + "..." : s;
-            }
-            catch
-            {
-                return string.Empty;
-            }
-        }
-
-        private DateTime lastLoginCheckUtc = DateTime.MinValue;
-        private bool? lastLoginCheckResult = null;
-
-        private void LogCookieSummary(string context, List<HttpCookie> cookies)
-        {
-            try
-            {
-                if (!IsVerboseLoggingEnabled)
-                {
-                    return;
-                }
-
-                cookies = cookies ?? new List<HttpCookie>();
-                var domains = cookies.Select(c => c?.Domain ?? string.Empty).Where(d => !string.IsNullOrEmpty(d)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-
-                int expiredCount = 0;
-                DateTime? minExpiry = null;
-                DateTime? maxExpiry = null;
-                foreach (var c in cookies)
-                {
-                    if (c?.Expires is DateTime dt)
-                    {
-                        if (dt <= DateTime.Now)
-                        {
-                            expiredCount++;
-                        }
-
-                        if (minExpiry == null || dt < minExpiry) minExpiry = dt;
-                        if (maxExpiry == null || dt > maxExpiry) maxExpiry = dt;
-                    }
-                }
-
-                Logger.Debug($"HLTB Auth: {context} cookies={cookies.Count} expired={expiredCount} domains=[{string.Join(",", domains)}] minExp={(minExpiry?.ToString("o") ?? "<none>")} maxExp={(maxExpiry?.ToString("o") ?? "<none>")}");
-            }
-            catch { }
-        }
-
-        private void FireAndForget(Task task, string context)
-        {
-            // Delegate to centralized helper to avoid duplication with HowLongToBeatDatabase
-            try
-            {
-                TaskHelpers.FireAndForget(task, context, LogManager.GetLogger());
-            }
-            catch { }
-        }
-
-        /// <summary>
-        /// Adjusts a semaphore to match a target limit by releasing extra permits or consuming existing permits.
-        /// The helper reads and writes the shared current limit via the provided delegates under the provided syncLock
-        /// to avoid races where callers supply stale snapshots. The method returns once adjustments are applied.
-        /// </summary>
-        private async Task AdjustSemaphoreLimit(
-            SemaphoreSlim semaphore,
-            Func<int> getCurrentLimit,
-            Action<int> setCurrentLimit,
-            int targetLimit,
-            object syncLock,
-            string context = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (semaphore == null) return;
-
-            try
-            {
-                int pendingConsume = 0;
-
-                targetLimit = Math.Max(0, Math.Min(SemaphoreUpperBound, targetLimit));
-
-                // Compute difference under lock and handle immediate increases (release permits)
-                if (syncLock == null)
-                {
-                    try { Logger.Warn("HLTB: AdjustSemaphoreLimit called with null syncLock; using internal lock"); } catch { }
-                    syncLock = new object();
-                }
-
-                int current = getCurrentLimit();
-                int diff;
-                lock (syncLock)
-                {
-                    current = getCurrentLimit();
-                    diff = targetLimit - current;
-                    if (diff > 0)
-                    {
-                        bool released = false;
-                        try
-                        {
-                            semaphore.Release(diff);
-                            released = true;
-                        }
-                        catch (Exception ex)
-                        {
-                            try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit failed to release {diff} permits (currentLimit={current}) ({context})"); } catch { }
-                        }
-
-                        try
-                        {
-                            if (released)
-                            {
-                                try { setCurrentLimit(targetLimit); } catch { }
-                            }
-                        }
-                        catch { }
-
-                        if (released) return;
-                    }
-
-                    if (diff < 0)
-                    {
-                        pendingConsume = -diff; // how many permits we need to consume to lower the available count
-                    }
-                }
-
-                if (pendingConsume > 0)
-                {
-                    // Try to consume up to pendingConsume permits with short, bounded waits so no orphaned tasks remain.
-                    int consumed = 0;
-                    TimeSpan tryWait = TimeSpan.FromMilliseconds(200);
-
-                    for (int i = 0; i < pendingConsume; i++)
-                    {
-                        try
-                        {
-                            if (cancellationToken.IsCancellationRequested)
-                            {
-                                break;
-                            }
-                            bool got = await semaphore.WaitAsync(tryWait, cancellationToken).ConfigureAwait(false);
-                            if (!got)
-                            {
-                                break; // timed out acquiring next permit; stop trying
-                            }
-
-                            consumed++;
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            break;
-                        }
-                        catch
-                        {
-                            break;
-                        }
-                    }
-
-                    // Update the shared currentLimit under lock based on how many permits we actually consumed
-                    lock (syncLock)
-                    {
-                        int originalLimit = getCurrentLimit();
-                        int newLimit;
-
-                        if (consumed == pendingConsume)
-                        {
-                            // Successfully consumed all intended permits
-                            newLimit = targetLimit;
-                        }
-                        else
-                        {
-                            // We consumed fewer than requested; lower the limit by the number we consumed (but not below 0)
-                            newLimit = Math.Max(0, originalLimit - consumed);
-                            // Ensure we don't accidentally increase above originalLimit
-                            newLimit = Math.Min(originalLimit, newLimit);
-                        }
-
-                        setCurrentLimit(newLimit);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit error ({context})"); } catch { }
-            }
-        }
-
-
-        /// <summary>
-        /// Tool for managing cookies for HowLongToBeat sessions.
-        /// </summary>
-        protected CookiesTools CookiesTools { get; }
-        /// <summary>
-        /// List of domains for which cookies are managed.
-        /// </summary>
-        protected List<string> CookiesDomains { get; }
-        /// <summary>
-        /// Path to the file where cookies are stored.
-        /// </summary>
-        internal string FileCookies { get; }
-
-        private readonly Type HapDocType;
-        private readonly bool HapAvailable;
-
-        private static string SearchUrl { get; set; } = null;
-        private static readonly object SearchUrlLock = new object();
-        private const int ScriptDownloadTimeoutMs = 5000;
-
-        private const int MaxParallelGameDataDownloads = 32;
-        private const int GameDataDownloadTimeoutMs = 15000;
-
-        private const int MaxParallelSearches = 96;
-
-        // Replace unbounded dictionaries with bounded LRU caches to avoid unbounded memory growth
-        private readonly LruCache<string, string> GamePageCache;
-        private readonly LruCache<string, SearchResult> SearchCache;
-        private SemaphoreSlim SearchSemaphore;
-        private AdaptiveConcurrencyController SearchConcurrencyController;
-        private readonly object SearchConcurrencySync = new object();
-        private int CurrentSearchLimit;
-        private int PersistentCacheHits = 0;
-        private int InMemoryCacheHits = 0;
-        private int PageFetches = 0;
-        private PageCache PageCache;
-        private AdaptiveConcurrencyController ConcurrencyController;
-        private SemaphoreSlim DynamicSemaphore;
-        private readonly object ConcurrencySync = new object();
-        private int CurrentSemaphoreLimit;
-        private const int SemaphoreUpperBound = 128;
-
-        private readonly HttpClient httpClient;
-        private Task PageCacheInitTask;
-        // Thread-local Random to provide jitter without creating many Sequential Random instances
-        private static readonly ThreadLocal<Random> _rnd = new ThreadLocal<Random>(() => new Random(Guid.NewGuid().GetHashCode()));
-
-        private readonly ConcurrentQueue<long> RecentSearchSamples = new ConcurrentQueue<long>();
-        private const int RecentSamplesWindow = 200;
-
-        private readonly ConcurrentQueue<int> RecentSearchStatusCodes = new ConcurrentQueue<int>();
-        private const int RecentStatusWindow = 200;
-
-        private DateTime SearchBackoffUntil = DateTime.MinValue;
-        private int SearchBackoffLimit = 0;
-        private readonly object BackoffSync = new object();
-
-        private string CachedAuthToken = null;
-        private DateTime CachedAuthTokenExpiry = DateTime.MinValue;
-        private readonly object AuthTokenSync = new object();
-
-        private CancellationTokenSource monitorCts;
-        private Task monitorTask;
-        private readonly object monitorSync = new object();
-        private bool _disposed = false;
-
-
-        #region Urls
-
-        private static string UrlBase => "https://howlongtobeat.com";
-
-        private static string UrlLogin => UrlBase + "/login";
-        private static string UrlLogOut => UrlBase + "/login?t=out";
-        private static string UrlSearchWeb => UrlBase + "/?q={0}";
-
-        private static string UrlUser => UrlBase + "/api/user";
-        private static string UrlUserStats => UrlUser + "?n={0}&s=stats";
-        private static string UrlUserStatsMore => UrlBase + "/user_stats_more";
-        private static string UrlUserStatsGamesList => UrlUser + "/{0}/stats";
-        private static string UrlUserGamesList => UrlUser + "/{0}/games/list";
-        private static string UrlUserStatsGameDetails => UrlBase + "/user_games_detail";
-
-        private static string UrlPostData => UrlBase + "/api/submit";
-        private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
-
-        private static string SearchEndPoint => "/api/locate";
-        private static string UrlSearch => UrlBase + SearchEndPoint;
-
-        private static string UrlGameImg => UrlBase + "/games/{0}";
-
-        private static string UrlGame => UrlBase + "/game?id={0}";
-
-        private static string UrlExportAll => UrlBase + "/user_export?all=1";
-
-        #endregion
-
-
-        private bool? _isConnected = null;
-        /// <summary>
-        /// Indicates if the user is currently connected (logged in).
-        /// </summary>
-        public bool? IsConnected { get => _isConnected; set => SetValue(ref _isConnected, value); }
-
-        /// <summary>
-        /// The username of the currently logged-in user.
-        /// </summary>
-        public string UserLogin { get; set; } = string.Empty;
-        /// <summary>
-        /// The user ID of the currently logged-in user.
-        /// </summary>
-        public int UserId { get; set; } = 0;
-
-        private bool IsFirst = true;
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HowLongToBeatApi"/> class.
-        /// </summary>
-        public HowLongToBeatApi()
-        {
-            try
-            {
-                var handler = new HttpClientHandler();
-                var prop = handler.GetType().GetProperty("MaxConnectionsPerServer");
-                if (prop != null && prop.CanWrite)
-                {
-                    prop.SetValue(handler, Math.Max(4, MaxParallelGameDataDownloads));
-                }
-                else
-                {
-                    Logger.Warn("HLTB: MaxConnectionsPerServer not available; using default connection limits");
-                }
-
-                httpClient = new HttpClient(handler)
-                {
-                    Timeout = System.Threading.Timeout.InfiniteTimeSpan
-                };
-                httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent);
-                try { httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", UrlBase); } catch { }
-                try { httpClient.DefaultRequestHeaders.Add("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error(ex, "HLTB: HttpClient init failed");
-                throw;
-            }
-
-            // Create default alias file if missing (non-fatal)
-            try
-            {
-                GameNameAliases.EnsureAliasFileExists(PluginDatabase?.Plugin?.GetPluginUserDataPath());
-            }
-            catch { }
-
-            // Cache HtmlAgilityPack availability once to avoid reflection on every request.
-            Type hapType = null;
-            try
-            {
-                hapType = Type.GetType("HtmlAgilityPack.HtmlDocument, HtmlAgilityPack");
-            }
-            catch { }
-            HapDocType = hapType;
-            HapAvailable = HapDocType != null;
-
-            UserLogin = PluginDatabase.PluginSettings.Settings.UserLogin;
-
-            CookiesDomains = new List<string>
-            {
-                ".howlongtobeat.com",
-                "howlongtobeat.com",
-                "www.howlongtobeat.com",
-                ".www.howlongtobeat.com"
-            };
-            string pathData = PluginDatabase.Paths.PluginUserDataPath;
-            FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.dat"));
-            CookiesTools = new CookiesTools(
-                PluginDatabase.PluginName,
-                "HowLongToBeat",
-                FileCookies,
-                CookiesDomains
-            );
-
-            try
-            {
-                var exists = File.Exists(FileCookies);
-                long size = 0;
-                if (exists)
-                {
-                    try { size = new FileInfo(FileCookies).Length; } catch { }
-                }
-
-                Logger.Info($"HLTB Auth: cookie file='{FileCookies}' exists={exists} size={size}");
-                if (exists)
-                {
-                    var stored = CookiesTools.GetStoredCookies();
-                    LogCookieSummary("startup stored", stored);
-
-                    // Non-critical: validate cookies on startup to help diagnose "logged out after restart".
-                    FireAndForget(Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await Task.Delay(2000).ConfigureAwait(false);
-                            bool ok = await GetIsUserLoggedInAsync().ConfigureAwait(false);
-                            Logger.Info($"HLTB Auth: startup cookie check ok={ok} userId={UserId}");
-                        }
-                        catch (Exception ex)
-                        {
-                            try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-                        }
-                    }), "startup cookie check");
-                }
-            }
-            catch { }
-
-            try
-            {
-                PageCacheInitTask = Task.Run(() =>
-                {
-                    PageCache localPc = null;
-                    try
-                    {
-                        localPc = new PageCache(PluginDatabase.Plugin.GetPluginUserDataPath());
-                        if (!_disposed)
-                        {
-                            PageCache = localPc;
-                            localPc = null;
-                        }
-                        else
-                        {
-                            try { (localPc as IDisposable)?.Dispose(); } catch { }
-                            localPc = null;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Common.LogError(ex, false);
-                        try { Logger.Warn("HLTB: PageCache init failed; proceeding without persistent cache"); } catch { }
-                        if (localPc != null)
-                        {
-                            try { (localPc as IDisposable)?.Dispose(); } catch { }
-                            localPc = null;
-                        }
-                    }
-                });
-
-                // Observe any exceptions from the init task so they don't go unobserved
-                PageCacheInitTask.ContinueWith(t =>
-                {
-                    try
-                    {
-                        if (t.IsFaulted && t.Exception != null)
-                        {
-                            Common.LogError(t.Exception, false);
-                        }
-                    }
-                    catch { }
-                }, TaskContinuationOptions.OnlyOnFaulted);
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false);
-            }
-
-            // Configure bounded in-memory caches to avoid unbounded growth during large imports
-            // Sizes are conservative defaults; can be tuned via settings later.
-            GamePageCache = new LruCache<string, string>(capacity: 2000, ttl: TimeSpan.FromHours(6));
-            SearchCache = new LruCache<string, SearchResult>(capacity: 2000, ttl: TimeSpan.FromHours(6));
-
-            try
-            {
-                ConcurrencyController = new AdaptiveConcurrencyController(MaxParallelGameDataDownloads, 4, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
-                DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads, SemaphoreUpperBound);
-                CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
-                try
-                {
-                    SearchConcurrencyController = new AdaptiveConcurrencyController(MaxParallelSearches, 2, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
-                    CurrentSearchLimit = MaxParallelSearches;
-                    SearchSemaphore = new SemaphoreSlim(MaxParallelSearches, SemaphoreUpperBound);
-                }
-                catch (Exception ex)
-                {
-                    try { Logger.Warn(ex, "HLTB: Search concurrency controller init failed; using basic semaphore"); } catch { }
-                    SearchSemaphore = new SemaphoreSlim(MaxParallelSearches);
-                    CurrentSearchLimit = MaxParallelSearches;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false);
-                try { Logger.Warn("HLTB: Adaptive concurrency init failed; using basic semaphore defaults"); } catch { }
-                DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads);
-                CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
-            }
-
-        }
-
-        public void StopMonitoring()
-        {
-            try
-            {
-                var task = monitorTask;
-                var cts = monitorCts;
-
-                try { cts?.Cancel(); } catch { }
-
-                if (task != null)
-                {
-                    try { task.Wait(5000); } catch { }
-                }
-
-                try { cts?.Dispose(); } catch { }
-                monitorCts = null;
-                monitorTask = null;
-            }
-            catch { }
-        }
-
-        private void EnsureMonitoringStarted()
-        {
-            if (_disposed) return;
-            lock (monitorSync)
-            {
-                if (monitorTask != null && !monitorTask.IsCompleted && monitorCts != null && !monitorCts.IsCancellationRequested)
-                {
-                    return;
-                }
-
-                try { monitorCts?.Dispose(); } catch { }
-                monitorCts = new CancellationTokenSource();
-                try
-                {
-                    monitorTask = Task.Run(async () =>
-                    {
-                        var token = monitorCts.Token;
-                        try
-                        {
-                            while (!token.IsCancellationRequested)
-                            {
-                                try
-                                {
-                                    if (token.IsCancellationRequested) break;
-                                    await Task.Delay(TimeSpan.FromSeconds(10), token).ConfigureAwait(false);
-                                }
-                                catch (OperationCanceledException)
-                                {
-                                    break;
-                                }
-                                catch (Exception) { }
-                                try
-                                {
-                                    int searchTarget;
-                                    bool searchForced = false;
-                                    try
-                                    {
-                                        int fixedTarget = MaxParallelSearches;
-                                        lock (BackoffSync)
-                                        {
-                                            if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
-                                            {
-                                                searchTarget = Math.Min(fixedTarget, SearchBackoffLimit);
-                                            }
-                                            else
-                                            {
-                                                searchTarget = fixedTarget;
-                                            }
-                                        }
-                                        searchForced = true;
-                                    }
-                                    catch
-                                    {
-                                        searchTarget = SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
-                                    }
-
-                                    int searchAvailable = 0;
-                                    int searchInFlight = 0;
-                                    int gameTarget = 0;
-                                    int gameAvailable = 0;
-                                    int gameInFlight = 0;
-                                    try
-                                    {
-                                        searchAvailable = SearchSemaphore?.CurrentCount ?? 0;
-                                        searchInFlight = Math.Max(0, searchTarget - searchAvailable);
-
-                                        gameTarget = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-                                        gameAvailable = DynamicSemaphore?.CurrentCount ?? 0;
-                                        gameInFlight = Math.Max(0, gameTarget - gameAvailable);
-                                    }
-                                    catch (ObjectDisposedException) { break; }
-                                    catch (InvalidOperationException) { break; }
-
-                                    var samples = RecentSearchSamples.ToArray();
-                                    double avg = samples.Length > 0 ? samples.Average() : 0;
-                                    double median = 0;
-                                    double p90 = 0;
-                                    if (samples.Length > 0)
-                                    {
-                                        var ordered = samples.OrderBy(x => x).ToArray();
-                                        median = ordered[ordered.Length / 2];
-                                        p90 = ordered[Math.Max(0, (int)Math.Floor(ordered.Length * 0.9) - 1)];
-                                    }
-
-                                    LogDebugVerbose($"HLTB Summary: searchTarget={searchTarget} searchInFlight={searchInFlight} gameTarget={gameTarget} gameInFlight={gameInFlight} avgSearchMs={Math.Round(avg, 1)} medianSearchMs={Math.Round(median, 1)} p90SearchMs={Math.Round(p90, 1)} persistentCacheHits={PersistentCacheHits} inMemoryCacheHits={InMemoryCacheHits} pageFetches={PageFetches} forced={searchForced}");
-                                }
-                                catch (Exception ex)
-                                {
-                                    try { Logger.Error(ex, "HLTB monitor loop error"); } catch { }
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            try { Logger.Error(ex, "HLTB monitor task terminated unexpectedly"); } catch { }
-                        }
-                    });
-                }
-                catch (Exception ex)
-                {
-                    try { Logger.Error(ex, "Failed to start HLTB monitor task"); } catch { }
-                }
-            }
-        }
-
-        ~HowLongToBeatApi()
-        {
-            try { Dispose(false); } catch { }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            try { GC.SuppressFinalize(this); } catch { }
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-
-            _disposed = true;
-
-            if (disposing)
-            {
-                try
-                {
-                    // Use StopMonitoring as single shutdown path; it will cancel and cleanup without blocking.
-                    try { StopMonitoring(); } catch { }
-                }
-                catch { }
-                finally
-                {
-                    monitorTask = null;
-                    monitorCts = null;
-                }
-
-                try { ConcurrencyController?.Dispose(); } catch { }
-                ConcurrencyController = null;
-                try { SearchConcurrencyController?.Dispose(); } catch { }
-                SearchConcurrencyController = null;
-
-                try { DynamicSemaphore?.Dispose(); } catch { }
-                DynamicSemaphore = null;
-                try { SearchSemaphore?.Dispose(); } catch { }
-                SearchSemaphore = null;
-
-                try { httpClient?.Dispose(); } catch { }
-
-                // Dispose page cache if it implements IDisposable
-                try
-                {
-                    if (PageCache is IDisposable disposableCache)
-                    {
-                        try { disposableCache.Dispose(); } catch { }
-                    }
-                }
-                catch { }
-                PageCache = null;
-            }
-        }
-
-
-        /// <summary>
-        /// Retrieves game data from HowLongToBeat by game ID.
-        /// </summary>
-        /// <param name="id">The game ID.</param>
-        /// <returns>Returns <see cref="HltbData"/> with game times, or null if not found.</returns>
-        private async Task<HltbData> GetGameData(string id, CancellationToken cancellationToken = default)
-        {
-            try { EnsureMonitoringStarted(); } catch { }
-            cancellationToken.ThrowIfCancellationRequested();
-            try
-            {
-                var init = PageCacheInitTask;
-                if (init != null && PageCache == null)
-                {
-                    await Task.WhenAny(init, Task.Delay(500)).ConfigureAwait(false);
-                }
-            }
-            catch { }
-            DateTime startTime = DateTime.UtcNow;
-            LogDebugVerbose($"GetGameData START id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} time={startTime:HH:mm:ss.fff}");
-
-            try
-            {
-                string jsonData = null;
-                try
-                {
-                    if (PageCache != null && PageCache.TryGetJson(id, out string cachedJson))
-                    {
-                        jsonData = cachedJson;
-                        try { System.Threading.Interlocked.Increment(ref PersistentCacheHits); } catch { }
-                        LogDebugVerbose($"GetGameData id={id} - persistent cache hit");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                }
-
-                int attempts = 0;
-                if (string.IsNullOrEmpty(jsonData))
-                {
-                    string response = string.Empty;
-                    int maxAttempts = 3;
-                    int baseDelayMs = 300;
-                    var rnd = _rnd.Value;
-                    while (attempts < maxAttempts)
-                    {
-                        attempts++;
-                        try
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            if (GamePageCache.TryGetValue(id, out string cached))
-                            {
-                                response = cached;
-                                try { System.Threading.Interlocked.Increment(ref InMemoryCacheHits); } catch { }
-                                LogDebugVerbose($"GetGameData id={id} - in-memory cache hit");
-                            }
-                            else
-                            {
-                                try
-                                {
-                                    using (var httpResp = await httpClient.GetAsync(string.Format(UrlGame, id), cancellationToken).ConfigureAwait(false))
-                                    {
-                                        if (!httpResp.IsSuccessStatusCode)
-                                        {
-                                            var code = (int)httpResp.StatusCode;
-                                            LogDebugVerbose($"GetGameData id={id} - HTTP {code} fetching page");
-                                            response = string.Empty;
-                                        }
-                                        else
-                                        {
-                                            response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                                        }
-                                    }
-                                }
-                                catch (HttpRequestException hre)
-                                {
-                                    Common.LogError(hre, false, false, PluginDatabase.PluginName);
-                                    response = string.Empty;
-                                }
-                            }
-
-                            if (!response.IsNullOrEmpty())
-                            {
-                                string maybeJson = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
-                                if (!maybeJson.IsNullOrEmpty())
-                                {
-                                    GamePageCache.TryAdd(id, response);
-                                    try
-                                    {
-                                        PageCache?.Set(id, maybeJson);
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                                    }
-                                    try { System.Threading.Interlocked.Increment(ref PageFetches); } catch { }
-                                    jsonData = maybeJson;
-                                    break;
-                                }
-                                else
-                                {
-                                    Common.LogDebug(true, $"GetGameData id={id} - extracted JSON was empty or incomplete (attempt={attempts})");
-                                    response = string.Empty;
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                        }
-
-                        if (attempts < maxAttempts)
-                        {
-                            var jitter = rnd.Next(0, 200);
-                            var delay = baseDelayMs * attempts + jitter;
-                            LogDebugVerbose($"GetGameData id={id} - retry {attempts} after {delay}ms");
-                            try { await Task.Delay(delay, cancellationToken); } catch (OperationCanceledException) { throw; }
-                        }
-                    }
-                }
-                if (string.IsNullOrEmpty(jsonData))
-                {
-                    Common.LogDebug(true, $"GetGameData id={id} - no JSON extracted after {attempts} attempts");
-                    Logger.Warn($"No GameData find with {id}");
-                    double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-                    try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
-                    LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
-                    return null;
-                }
-
-                _ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
-                if (parseEx != null)
-                {
-                    Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
-                }
-
-                GameData gameData = next_data?.Props?.PageProps?.Game?.Data?.Game != null
-                    ? next_data.Props.PageProps.Game.Data.Game.FirstOrDefault()
-                    : null;
-
-                if (gameData != null)
-                {
-                    HltbData hltbData = new HltbData
-                    {
-                        MainStoryClassic = gameData.CompMain,
-                        MainExtraClassic = gameData.CompPlus,
-                        CompletionistClassic = gameData.Comp100,
-                        SoloClassic = gameData.CompAll,
-                        CoOpClassic = gameData.InvestedCo,
-                        VsClassic = gameData.InvestedMp,
-
-                        MainStoryMedian = gameData.CompMainMed,
-                        MainExtraMedian = gameData.CompPlusMed,
-                        CompletionistMedian = gameData.Comp100Med,
-                        SoloMedian = gameData.CompAllMed,
-                        CoOpMedian = gameData.InvestedCoMed,
-                        VsMedian = gameData.InvestedMpMed,
-
-                        MainStoryAverage = gameData.CompMainAvg,
-                        MainExtraAverage = gameData.CompPlusAvg,
-                        CompletionistAverage = gameData.Comp100Avg,
-                        SoloAverage = gameData.CompAllAvg,
-                        CoOpAverage = gameData.InvestedCoAvg,
-                        VsAverage = gameData.InvestedMpAvg,
-
-                        MainStoryRushed = gameData.CompMainL,
-                        MainExtraRushed = gameData.CompPlusL,
-                        CompletionistRushed = gameData.Comp100L,
-                        SoloRushed = gameData.CompAllL,
-                        CoOpRushed = gameData.InvestedCoL,
-                        VsRushed = gameData.InvestedMpL,
-
-                        MainStoryLeisure = gameData.CompMainH,
-                        MainExtraLeisure = gameData.CompPlusH,
-                        CompletionistLeisure = gameData.Comp100H,
-                        SoloLeisure = gameData.CompAllH,
-                        CoOpLeisure = gameData.InvestedCoH,
-                        VsLeisure = gameData.InvestedMpH
-                    };
-
-                    double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-                    try { ConcurrencyController?.ReportSample(elapsed, true); } catch { }
-                    LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
-                    return hltbData;
-                }
-                else
-                {
-                    Logger.Warn($"No GameData find with {id}");
-                    double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-                    try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
-                    LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
-                    return null;
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                Logger.Info($"GetGameData ERROR id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={(DateTime.UtcNow - startTime).TotalMilliseconds}ms");
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Updates the HLTB data for a user game entry.
-        /// </summary>
-        /// <param name="hltbDataUser">The user game data to update.</param>
-        /// <returns>Returns the updated <see cref="HltbDataUser"/>.</returns>
-        public async Task<HltbDataUser> UpdateGameData(HltbDataUser hltbDataUser)
-        {
-            try
-            {
-                HltbData hltbData = await GetGameData(hltbDataUser.Id);
-                hltbDataUser.GameHltbData = hltbData ?? hltbDataUser.GameHltbData;
-                return hltbDataUser;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return null;
-            }
-        }
-
-
-        #region Search
-
-        /// <summary>
-        /// Retrieves the search URL from the website scripts.
-        /// </summary>
-        /// <returns>The search endpoint URL.</returns>
-        private async Task<string> GetSearchUrl()
-        {
-            if (!SearchUrl.IsNullOrEmpty())
-            {
-                return SearchUrl;
-            }
-
-            try
-            {
-                string url = UrlBase;
-
-                string response = null;
-                using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
-                {
-                    try
-                    {
-                        using (var httpResp = await httpClient.GetAsync(url, cts.Token).ConfigureAwait(false))
-                        {
-                            if (!httpResp.IsSuccessStatusCode)
-                            {
-                                try { Logger.Warn($"HTTP {(int)httpResp.StatusCode} downloading {url}"); } catch { }
-                                return "/api/s";
-                            }
-
-                            response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        }
-                    }
-                    catch (TaskCanceledException)
-                    {
-                        try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {url}"); } catch { }
-                        return "/api/s";
-                    }
-                    catch (Exception ex)
-                    {
-                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                        return "/api/s";
-                    }
-                }
-
-                // Try to extract script URLs via optional HtmlAgilityPack helper (reflection). Fall back to regex if unavailable.
-                List<string> scriptUrls = ExtractScriptUrlsWithHap(response) ?? new List<string>();
-                if (scriptUrls.Count == 0)
-                {
-
-                    var matches = MyRegex().Matches(response);
-                    foreach (Match match in matches)
-                    {
-                        scriptUrls.Add(match.Groups[1].Value);
-                    }
-                }
-
-                var ordered = scriptUrls.Where(s => s.Contains("_app-")).Concat(scriptUrls).Where(s => !string.IsNullOrEmpty(s)).Distinct();
-                foreach (string sUrl in ordered)
-                {
-                    string scriptUrl = sUrl;
-                    if (!scriptUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-                    {
-                        scriptUrl = UrlBase + scriptUrl;
-                    }
-
-                    string scriptContent = null;
-                    using (var ctsScript = new CancellationTokenSource(ScriptDownloadTimeoutMs))
-                    {
-                        try
-                        {
-                            using (var scriptResp = await httpClient.GetAsync(scriptUrl, ctsScript.Token).ConfigureAwait(false))
-                            {
-                                if (!scriptResp.IsSuccessStatusCode)
-                                {
-                                    try { Logger.Warn($"HTTP {(int)scriptResp.StatusCode} downloading {scriptUrl}"); } catch { }
-                                    continue;
-                                }
-
-                                scriptContent = await scriptResp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            }
-                        }
-                        catch (TaskCanceledException)
-                        {
-                            try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {scriptUrl}"); } catch { }
-                            continue;
-                        }
-                        catch (Exception ex)
-                        {
-                            Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                            continue;
-                        }
-                    }
-
-                    string pattern = "fetch\\s*\\(\\s*[\"']\\/api\\/([a-zA-Z0-9_\\/]+)[^\"']*[\"']\\s*,\\s*\\{[^}]*method:\\s*[\"']POST[\"'][^}]*\\}";
-                    var searchMatch = Regex.Match(scriptContent, pattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
-                    if (searchMatch.Success)
-                    {
-                        string suffix = searchMatch.Groups[1].Value;
-                        if (suffix.Contains("/"))
-                        {
-                            suffix = suffix.Split('/')[0];
-                        }
-
-                        if (suffix != "find")
-                        {
-                            lock (SearchUrlLock)
-                            {
-                                if (SearchUrl.IsNullOrEmpty())
-                                {
-                                    SearchUrl = "/api/" + suffix;
-                                }
-                            }
-                            return SearchUrl;
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-            }
-
-            return "/api/s";
-        }
+	public partial class HowLongToBeatApi : ObservableObject, IDisposable
+	{
+		private static ILogger Logger => LogManager.GetLogger();
+
+		private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
+
+		// Helper to centralize verbose logging checks
+		private static bool IsVerboseLoggingEnabled => PluginDatabase?.PluginSettings?.Settings is HowLongToBeatSettings _vs && _vs.EnableVerboseLogging;
+
+		private void LogDebugVerbose(string message)
+		{
+			try
+			{
+				if (IsVerboseLoggingEnabled)
+				{
+					Logger.Debug(message);
+				}
+			}
+			catch { }
+		}
+
+		private string SafeStr(string s)
+		{
+			try
+			{
+				if (s == null)
+				{
+					return string.Empty;
+				}
+
+				s = s.Replace("\r", " ").Replace("\n", " ");
+				return s.Length > 120 ? s.Substring(0, 120) + "..." : s;
+			}
+			catch
+			{
+				return string.Empty;
+			}
+		}
+
+		private DateTime lastLoginCheckUtc = DateTime.MinValue;
+		private bool? lastLoginCheckResult = null;
+
+		private void LogCookieSummary(string context, List<HttpCookie> cookies)
+		{
+			try
+			{
+				if (!IsVerboseLoggingEnabled)
+				{
+					return;
+				}
+
+				cookies = cookies ?? new List<HttpCookie>();
+				var domains = cookies.Select(c => c?.Domain ?? string.Empty).Where(d => !string.IsNullOrEmpty(d)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+				int expiredCount = 0;
+				DateTime? minExpiry = null;
+				DateTime? maxExpiry = null;
+				foreach (var c in cookies)
+				{
+					if (c?.Expires is DateTime dt)
+					{
+						if (dt <= DateTime.Now)
+						{
+							expiredCount++;
+						}
+
+						if (minExpiry == null || dt < minExpiry) minExpiry = dt;
+						if (maxExpiry == null || dt > maxExpiry) maxExpiry = dt;
+					}
+				}
+
+				Logger.Debug($"HLTB Auth: {context} cookies={cookies.Count} expired={expiredCount} domains=[{string.Join(",", domains)}] minExp={(minExpiry?.ToString("o") ?? "<none>")} maxExp={(maxExpiry?.ToString("o") ?? "<none>")}");
+			}
+			catch { }
+		}
+
+		private void FireAndForget(Task task, string context)
+		{
+			// Delegate to centralized helper to avoid duplication with HowLongToBeatDatabase
+			try
+			{
+				TaskHelpers.FireAndForget(task, context, LogManager.GetLogger());
+			}
+			catch { }
+		}
+
+		/// <summary>
+		/// Adjusts a semaphore to match a target limit by releasing extra permits or consuming existing permits.
+		/// The helper reads and writes the shared current limit via the provided delegates under the provided syncLock
+		/// to avoid races where callers supply stale snapshots. The method returns once adjustments are applied.
+		/// </summary>
+		private async Task AdjustSemaphoreLimit(
+			SemaphoreSlim semaphore,
+			Func<int> getCurrentLimit,
+			Action<int> setCurrentLimit,
+			int targetLimit,
+			object syncLock,
+			string context = null,
+			CancellationToken cancellationToken = default)
+		{
+			if (semaphore == null) return;
+
+			try
+			{
+				int pendingConsume = 0;
+
+				targetLimit = Math.Max(0, Math.Min(SemaphoreUpperBound, targetLimit));
+
+				// Compute difference under lock and handle immediate increases (release permits)
+				if (syncLock == null)
+				{
+					try { Logger.Warn("HLTB: AdjustSemaphoreLimit called with null syncLock; using internal lock"); } catch { }
+					syncLock = new object();
+				}
+
+				int current = getCurrentLimit();
+				int diff;
+				lock (syncLock)
+				{
+					current = getCurrentLimit();
+					diff = targetLimit - current;
+					if (diff > 0)
+					{
+						bool released = false;
+						try
+						{
+							semaphore.Release(diff);
+							released = true;
+						}
+						catch (Exception ex)
+						{
+							try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit failed to release {diff} permits (currentLimit={current}) ({context})"); } catch { }
+						}
+
+						try
+						{
+							if (released)
+							{
+								try { setCurrentLimit(targetLimit); } catch { }
+							}
+						}
+						catch { }
+
+						if (released) return;
+					}
+
+					if (diff < 0)
+					{
+						pendingConsume = -diff; // how many permits we need to consume to lower the available count
+					}
+				}
+
+				if (pendingConsume > 0)
+				{
+					// Try to consume up to pendingConsume permits with short, bounded waits so no orphaned tasks remain.
+					int consumed = 0;
+					TimeSpan tryWait = TimeSpan.FromMilliseconds(200);
+
+					for (int i = 0; i < pendingConsume; i++)
+					{
+						try
+						{
+							if (cancellationToken.IsCancellationRequested)
+							{
+								break;
+							}
+							bool got = await semaphore.WaitAsync(tryWait, cancellationToken).ConfigureAwait(false);
+							if (!got)
+							{
+								break; // timed out acquiring next permit; stop trying
+							}
+
+							consumed++;
+						}
+						catch (OperationCanceledException)
+						{
+							break;
+						}
+						catch
+						{
+							break;
+						}
+					}
+
+					// Update the shared currentLimit under lock based on how many permits we actually consumed
+					lock (syncLock)
+					{
+						int originalLimit = getCurrentLimit();
+						int newLimit;
+
+						if (consumed == pendingConsume)
+						{
+							// Successfully consumed all intended permits
+							newLimit = targetLimit;
+						}
+						else
+						{
+							// We consumed fewer than requested; lower the limit by the number we consumed (but not below 0)
+							newLimit = Math.Max(0, originalLimit - consumed);
+							// Ensure we don't accidentally increase above originalLimit
+							newLimit = Math.Min(originalLimit, newLimit);
+						}
+
+						setCurrentLimit(newLimit);
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit error ({context})"); } catch { }
+			}
+		}
+
+
+		/// <summary>
+		/// Tool for managing cookies for HowLongToBeat sessions.
+		/// </summary>
+		protected CookiesTools CookiesTools { get; }
+		/// <summary>
+		/// List of domains for which cookies are managed.
+		/// </summary>
+		protected List<string> CookiesDomains { get; }
+		/// <summary>
+		/// Path to the file where cookies are stored.
+		/// </summary>
+		internal string FileCookies { get; }
+
+		private readonly Type HapDocType;
+		private readonly bool HapAvailable;
+
+		private static string SearchUrl { get; set; } = null;
+		private static readonly object SearchUrlLock = new object();
+		private const int ScriptDownloadTimeoutMs = 5000;
+
+		private const int MaxParallelGameDataDownloads = 32;
+		private const int GameDataDownloadTimeoutMs = 15000;
+
+		private const int MaxParallelSearches = 96;
+
+		// Replace unbounded dictionaries with bounded LRU caches to avoid unbounded memory growth
+		private readonly LruCache<string, string> GamePageCache;
+		private readonly LruCache<string, SearchResult> SearchCache;
+		private SemaphoreSlim SearchSemaphore;
+		private AdaptiveConcurrencyController SearchConcurrencyController;
+		private readonly object SearchConcurrencySync = new object();
+		private int CurrentSearchLimit;
+		private int PersistentCacheHits = 0;
+		private int InMemoryCacheHits = 0;
+		private int PageFetches = 0;
+		private PageCache PageCache;
+		private AdaptiveConcurrencyController ConcurrencyController;
+		private SemaphoreSlim DynamicSemaphore;
+		private readonly object ConcurrencySync = new object();
+		private int CurrentSemaphoreLimit;
+		private const int SemaphoreUpperBound = 128;
+
+		private readonly HttpClient httpClient;
+		private Task PageCacheInitTask;
+		// Thread-local Random to provide jitter without creating many Sequential Random instances
+		private static readonly ThreadLocal<Random> _rnd = new ThreadLocal<Random>(() => new Random(Guid.NewGuid().GetHashCode()));
+
+		private readonly ConcurrentQueue<long> RecentSearchSamples = new ConcurrentQueue<long>();
+		private const int RecentSamplesWindow = 200;
+
+		private readonly ConcurrentQueue<int> RecentSearchStatusCodes = new ConcurrentQueue<int>();
+		private const int RecentStatusWindow = 200;
+
+		private DateTime SearchBackoffUntil = DateTime.MinValue;
+		private int SearchBackoffLimit = 0;
+		private readonly object BackoffSync = new object();
+
+		private string CachedAuthToken = null;
+		private DateTime CachedAuthTokenExpiry = DateTime.MinValue;
+		private readonly object AuthTokenSync = new object();
+
+		private CancellationTokenSource monitorCts;
+		private Task monitorTask;
+		private readonly object monitorSync = new object();
+		private bool _disposed = false;
+
+
+		#region Urls
+
+		private static string UrlBase => "https://howlongtobeat.com";
+
+		private static string UrlLogin => UrlBase + "/login";
+		private static string UrlLogOut => UrlBase + "/login?t=out";
+		private static string UrlSearchWeb => UrlBase + "/?q={0}";
+
+		private static string UrlUser => UrlBase + "/api/user";
+		private static string UrlUserStats => UrlUser + "?n={0}&s=stats";
+		private static string UrlUserStatsMore => UrlBase + "/user_stats_more";
+		private static string UrlUserStatsGamesList => UrlUser + "/{0}/stats";
+		private static string UrlUserGamesList => UrlUser + "/{0}/games/list";
+		private static string UrlUserStatsGameDetails => UrlBase + "/user_games_detail";
+
+		private static string UrlPostData => UrlBase + "/api/submit";
+		private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
+
+		private static string SearchEndPoint => "/api/locate";
+		private static string UrlSearch => UrlBase + SearchEndPoint;
+
+		private static string UrlGameImg => UrlBase + "/games/{0}";
+
+		private static string UrlGame => UrlBase + "/game?id={0}";
+
+		private static string UrlExportAll => UrlBase + "/user_export?all=1";
+
+		#endregion
+
+
+		private bool? _isConnected = null;
+		/// <summary>
+		/// Indicates if the user is currently connected (logged in).
+		/// </summary>
+		public bool? IsConnected { get => _isConnected; set => SetValue(ref _isConnected, value); }
+
+		/// <summary>
+		/// The username of the currently logged-in user.
+		/// </summary>
+		public string UserLogin { get; set; } = string.Empty;
+		/// <summary>
+		/// The user ID of the currently logged-in user.
+		/// </summary>
+		public int UserId { get; set; } = 0;
+
+		private bool IsFirst = true;
+
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="HowLongToBeatApi"/> class.
+		/// </summary>
+		public HowLongToBeatApi()
+		{
+			try
+			{
+				var handler = new HttpClientHandler();
+				var prop = handler.GetType().GetProperty("MaxConnectionsPerServer");
+				if (prop != null && prop.CanWrite)
+				{
+					prop.SetValue(handler, Math.Max(4, MaxParallelGameDataDownloads));
+				}
+				else
+				{
+					Logger.Warn("HLTB: MaxConnectionsPerServer not available; using default connection limits");
+				}
+
+				httpClient = new HttpClient(handler)
+				{
+					Timeout = System.Threading.Timeout.InfiniteTimeSpan
+				};
+				httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent);
+				try { httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", UrlBase); } catch { }
+				try { httpClient.DefaultRequestHeaders.Add("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
+			}
+			catch (Exception ex)
+			{
+				Logger.Error(ex, "HLTB: HttpClient init failed");
+				throw;
+			}
+
+			// Create default alias file if missing (non-fatal)
+			try
+			{
+				GameNameAliases.EnsureAliasFileExists(PluginDatabase?.Plugin?.GetPluginUserDataPath());
+			}
+			catch { }
+
+			// Cache HtmlAgilityPack availability once to avoid reflection on every request.
+			Type hapType = null;
+			try
+			{
+				hapType = Type.GetType("HtmlAgilityPack.HtmlDocument, HtmlAgilityPack");
+			}
+			catch { }
+			HapDocType = hapType;
+			HapAvailable = HapDocType != null;
+
+			UserLogin = PluginDatabase.PluginSettings.Settings.UserLogin;
+
+			CookiesDomains = new List<string>
+			{
+				".howlongtobeat.com",
+				"howlongtobeat.com",
+				"www.howlongtobeat.com",
+				".www.howlongtobeat.com"
+			};
+			string pathData = PluginDatabase.Paths.PluginUserDataPath;
+			FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.dat"));
+			CookiesTools = new CookiesTools(
+				PluginDatabase.PluginName,
+				"HowLongToBeat",
+				FileCookies,
+				CookiesDomains
+			);
+
+			try
+			{
+				var exists = File.Exists(FileCookies);
+				long size = 0;
+				if (exists)
+				{
+					try { size = new FileInfo(FileCookies).Length; } catch { }
+				}
+
+				Logger.Info($"HLTB Auth: cookie file='{FileCookies}' exists={exists} size={size}");
+				if (exists)
+				{
+					var stored = CookiesTools.GetStoredCookies();
+					LogCookieSummary("startup stored", stored);
+
+					// Non-critical: validate cookies on startup to help diagnose "logged out after restart".
+					FireAndForget(Task.Run(async () =>
+					{
+						try
+						{
+							await Task.Delay(2000).ConfigureAwait(false);
+							bool ok = await GetIsUserLoggedInAsync().ConfigureAwait(false);
+							Logger.Info($"HLTB Auth: startup cookie check ok={ok} userId={UserId}");
+						}
+						catch (Exception ex)
+						{
+							try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+						}
+					}), "startup cookie check");
+				}
+			}
+			catch { }
+
+			try
+			{
+				PageCacheInitTask = Task.Run(() =>
+				{
+					PageCache localPc = null;
+					try
+					{
+						localPc = new PageCache(PluginDatabase.Plugin.GetPluginUserDataPath());
+						if (!_disposed)
+						{
+							PageCache = localPc;
+							localPc = null;
+						}
+						else
+						{
+							try { (localPc as IDisposable)?.Dispose(); } catch { }
+							localPc = null;
+						}
+					}
+					catch (Exception ex)
+					{
+						Common.LogError(ex, false);
+						try { Logger.Warn("HLTB: PageCache init failed; proceeding without persistent cache"); } catch { }
+						if (localPc != null)
+						{
+							try { (localPc as IDisposable)?.Dispose(); } catch { }
+							localPc = null;
+						}
+					}
+				});
+
+				// Observe any exceptions from the init task so they don't go unobserved
+				PageCacheInitTask.ContinueWith(t =>
+				{
+					try
+					{
+						if (t.IsFaulted && t.Exception != null)
+						{
+							Common.LogError(t.Exception, false);
+						}
+					}
+					catch { }
+				}, TaskContinuationOptions.OnlyOnFaulted);
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false);
+			}
+
+			// Configure bounded in-memory caches to avoid unbounded growth during large imports
+			// Sizes are conservative defaults; can be tuned via settings later.
+			GamePageCache = new LruCache<string, string>(capacity: 2000, ttl: TimeSpan.FromHours(6));
+			SearchCache = new LruCache<string, SearchResult>(capacity: 2000, ttl: TimeSpan.FromHours(6));
+
+			try
+			{
+				ConcurrencyController = new AdaptiveConcurrencyController(MaxParallelGameDataDownloads, 4, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
+				DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads, SemaphoreUpperBound);
+				CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
+				try
+				{
+					SearchConcurrencyController = new AdaptiveConcurrencyController(MaxParallelSearches, 2, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
+					CurrentSearchLimit = MaxParallelSearches;
+					SearchSemaphore = new SemaphoreSlim(MaxParallelSearches, SemaphoreUpperBound);
+				}
+				catch (Exception ex)
+				{
+					try { Logger.Warn(ex, "HLTB: Search concurrency controller init failed; using basic semaphore"); } catch { }
+					SearchSemaphore = new SemaphoreSlim(MaxParallelSearches);
+					CurrentSearchLimit = MaxParallelSearches;
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false);
+				try { Logger.Warn("HLTB: Adaptive concurrency init failed; using basic semaphore defaults"); } catch { }
+				DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads);
+				CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
+			}
+
+		}
+
+		public void StopMonitoring()
+		{
+			try
+			{
+				var task = monitorTask;
+				var cts = monitorCts;
+
+				try { cts?.Cancel(); } catch { }
+
+				if (task != null)
+				{
+					try { task.Wait(5000); } catch { }
+				}
+
+				try { cts?.Dispose(); } catch { }
+				monitorCts = null;
+				monitorTask = null;
+			}
+			catch { }
+		}
+
+		private void EnsureMonitoringStarted()
+		{
+			if (_disposed) return;
+			lock (monitorSync)
+			{
+				if (monitorTask != null && !monitorTask.IsCompleted && monitorCts != null && !monitorCts.IsCancellationRequested)
+				{
+					return;
+				}
+
+				try { monitorCts?.Dispose(); } catch { }
+				monitorCts = new CancellationTokenSource();
+				try
+				{
+					monitorTask = Task.Run(async () =>
+					{
+						var token = monitorCts.Token;
+						try
+						{
+							while (!token.IsCancellationRequested)
+							{
+								try
+								{
+									if (token.IsCancellationRequested) break;
+									await Task.Delay(TimeSpan.FromSeconds(10), token).ConfigureAwait(false);
+								}
+								catch (OperationCanceledException)
+								{
+									break;
+								}
+								catch (Exception) { }
+								try
+								{
+									int searchTarget;
+									bool searchForced = false;
+									try
+									{
+										int fixedTarget = MaxParallelSearches;
+										lock (BackoffSync)
+										{
+											if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
+											{
+												searchTarget = Math.Min(fixedTarget, SearchBackoffLimit);
+											}
+											else
+											{
+												searchTarget = fixedTarget;
+											}
+										}
+										searchForced = true;
+									}
+									catch
+									{
+										searchTarget = SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
+									}
+
+									int searchAvailable = 0;
+									int searchInFlight = 0;
+									int gameTarget = 0;
+									int gameAvailable = 0;
+									int gameInFlight = 0;
+									try
+									{
+										searchAvailable = SearchSemaphore?.CurrentCount ?? 0;
+										searchInFlight = Math.Max(0, searchTarget - searchAvailable);
+
+										gameTarget = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+										gameAvailable = DynamicSemaphore?.CurrentCount ?? 0;
+										gameInFlight = Math.Max(0, gameTarget - gameAvailable);
+									}
+									catch (ObjectDisposedException) { break; }
+									catch (InvalidOperationException) { break; }
+
+									var samples = RecentSearchSamples.ToArray();
+									double avg = samples.Length > 0 ? samples.Average() : 0;
+									double median = 0;
+									double p90 = 0;
+									if (samples.Length > 0)
+									{
+										var ordered = samples.OrderBy(x => x).ToArray();
+										median = ordered[ordered.Length / 2];
+										p90 = ordered[Math.Max(0, (int)Math.Floor(ordered.Length * 0.9) - 1)];
+									}
+
+									LogDebugVerbose($"HLTB Summary: searchTarget={searchTarget} searchInFlight={searchInFlight} gameTarget={gameTarget} gameInFlight={gameInFlight} avgSearchMs={Math.Round(avg, 1)} medianSearchMs={Math.Round(median, 1)} p90SearchMs={Math.Round(p90, 1)} persistentCacheHits={PersistentCacheHits} inMemoryCacheHits={InMemoryCacheHits} pageFetches={PageFetches} forced={searchForced}");
+								}
+								catch (Exception ex)
+								{
+									try { Logger.Error(ex, "HLTB monitor loop error"); } catch { }
+								}
+							}
+						}
+						catch (Exception ex)
+						{
+							try { Logger.Error(ex, "HLTB monitor task terminated unexpectedly"); } catch { }
+						}
+					});
+				}
+				catch (Exception ex)
+				{
+					try { Logger.Error(ex, "Failed to start HLTB monitor task"); } catch { }
+				}
+			}
+		}
+
+		~HowLongToBeatApi()
+		{
+			try { Dispose(false); } catch { }
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			try { GC.SuppressFinalize(this); } catch { }
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (_disposed) return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				try
+				{
+					// Use StopMonitoring as single shutdown path; it will cancel and cleanup without blocking.
+					try { StopMonitoring(); } catch { }
+				}
+				catch { }
+				finally
+				{
+					monitorTask = null;
+					monitorCts = null;
+				}
+
+				try { ConcurrencyController?.Dispose(); } catch { }
+				ConcurrencyController = null;
+				try { SearchConcurrencyController?.Dispose(); } catch { }
+				SearchConcurrencyController = null;
+
+				try { DynamicSemaphore?.Dispose(); } catch { }
+				DynamicSemaphore = null;
+				try { SearchSemaphore?.Dispose(); } catch { }
+				SearchSemaphore = null;
+
+				try { httpClient?.Dispose(); } catch { }
+
+				// Dispose page cache if it implements IDisposable
+				try
+				{
+					if (PageCache is IDisposable disposableCache)
+					{
+						try { disposableCache.Dispose(); } catch { }
+					}
+				}
+				catch { }
+				PageCache = null;
+			}
+		}
+
+
+		/// <summary>
+		/// Retrieves game data from HowLongToBeat by game ID.
+		/// </summary>
+		/// <param name="id">The game ID.</param>
+		/// <returns>Returns <see cref="HltbData"/> with game times, or null if not found.</returns>
+		private async Task<HltbData> GetGameData(string id, CancellationToken cancellationToken = default)
+		{
+			try { EnsureMonitoringStarted(); } catch { }
+			cancellationToken.ThrowIfCancellationRequested();
+			try
+			{
+				var init = PageCacheInitTask;
+				if (init != null && PageCache == null)
+				{
+					await Task.WhenAny(init, Task.Delay(500)).ConfigureAwait(false);
+				}
+			}
+			catch { }
+			DateTime startTime = DateTime.UtcNow;
+			LogDebugVerbose($"GetGameData START id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} time={startTime:HH:mm:ss.fff}");
+
+			try
+			{
+				string jsonData = null;
+				try
+				{
+					if (PageCache != null && PageCache.TryGetJson(id, out string cachedJson))
+					{
+						jsonData = cachedJson;
+						try { System.Threading.Interlocked.Increment(ref PersistentCacheHits); } catch { }
+						LogDebugVerbose($"GetGameData id={id} - persistent cache hit");
+					}
+				}
+				catch (Exception ex)
+				{
+					Common.LogError(ex, false, false, PluginDatabase.PluginName);
+				}
+
+				int attempts = 0;
+				if (string.IsNullOrEmpty(jsonData))
+				{
+					string response = string.Empty;
+					int maxAttempts = 3;
+					int baseDelayMs = 300;
+					var rnd = _rnd.Value;
+					while (attempts < maxAttempts)
+					{
+						attempts++;
+						try
+						{
+							cancellationToken.ThrowIfCancellationRequested();
+							if (GamePageCache.TryGetValue(id, out string cached))
+							{
+								response = cached;
+								try { System.Threading.Interlocked.Increment(ref InMemoryCacheHits); } catch { }
+								LogDebugVerbose($"GetGameData id={id} - in-memory cache hit");
+							}
+							else
+							{
+								try
+								{
+									using (var httpResp = await httpClient.GetAsync(string.Format(UrlGame, id), cancellationToken).ConfigureAwait(false))
+									{
+										if (!httpResp.IsSuccessStatusCode)
+										{
+											var code = (int)httpResp.StatusCode;
+											LogDebugVerbose($"GetGameData id={id} - HTTP {code} fetching page");
+											response = string.Empty;
+										}
+										else
+										{
+											response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+										}
+									}
+								}
+								catch (HttpRequestException hre)
+								{
+									Common.LogError(hre, false, false, PluginDatabase.PluginName);
+									response = string.Empty;
+								}
+							}
+
+							if (!response.IsNullOrEmpty())
+							{
+								string maybeJson = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
+								if (!maybeJson.IsNullOrEmpty())
+								{
+									GamePageCache.TryAdd(id, response);
+									try
+									{
+										PageCache?.Set(id, maybeJson);
+									}
+									catch (Exception ex)
+									{
+										Common.LogError(ex, false, false, PluginDatabase.PluginName);
+									}
+									try { System.Threading.Interlocked.Increment(ref PageFetches); } catch { }
+									jsonData = maybeJson;
+									break;
+								}
+								else
+								{
+									Common.LogDebug(true, $"GetGameData id={id} - extracted JSON was empty or incomplete (attempt={attempts})");
+									response = string.Empty;
+								}
+							}
+						}
+						catch (Exception ex)
+						{
+							Common.LogError(ex, false, false, PluginDatabase.PluginName);
+						}
+
+						if (attempts < maxAttempts)
+						{
+							var jitter = rnd.Next(0, 200);
+							var delay = baseDelayMs * attempts + jitter;
+							LogDebugVerbose($"GetGameData id={id} - retry {attempts} after {delay}ms");
+							try { await Task.Delay(delay, cancellationToken); } catch (OperationCanceledException) { throw; }
+						}
+					}
+				}
+				if (string.IsNullOrEmpty(jsonData))
+				{
+					Common.LogDebug(true, $"GetGameData id={id} - no JSON extracted after {attempts} attempts");
+					Logger.Warn($"No GameData find with {id}");
+					double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+					try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
+					LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
+					return null;
+				}
+
+				_ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
+				if (parseEx != null)
+				{
+					Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
+				}
+
+				GameData gameData = next_data?.Props?.PageProps?.Game?.Data?.Game != null
+					? next_data.Props.PageProps.Game.Data.Game.FirstOrDefault()
+					: null;
+
+				if (gameData != null)
+				{
+					HltbData hltbData = new HltbData
+					{
+						MainStoryClassic = gameData.CompMain,
+						MainExtraClassic = gameData.CompPlus,
+						CompletionistClassic = gameData.Comp100,
+						SoloClassic = gameData.CompAll,
+						CoOpClassic = gameData.InvestedCo,
+						VsClassic = gameData.InvestedMp,
+
+						MainStoryMedian = gameData.CompMainMed,
+						MainExtraMedian = gameData.CompPlusMed,
+						CompletionistMedian = gameData.Comp100Med,
+						SoloMedian = gameData.CompAllMed,
+						CoOpMedian = gameData.InvestedCoMed,
+						VsMedian = gameData.InvestedMpMed,
+
+						MainStoryAverage = gameData.CompMainAvg,
+						MainExtraAverage = gameData.CompPlusAvg,
+						CompletionistAverage = gameData.Comp100Avg,
+						SoloAverage = gameData.CompAllAvg,
+						CoOpAverage = gameData.InvestedCoAvg,
+						VsAverage = gameData.InvestedMpAvg,
+
+						MainStoryRushed = gameData.CompMainL,
+						MainExtraRushed = gameData.CompPlusL,
+						CompletionistRushed = gameData.Comp100L,
+						SoloRushed = gameData.CompAllL,
+						CoOpRushed = gameData.InvestedCoL,
+						VsRushed = gameData.InvestedMpL,
+
+						MainStoryLeisure = gameData.CompMainH,
+						MainExtraLeisure = gameData.CompPlusH,
+						CompletionistLeisure = gameData.Comp100H,
+						SoloLeisure = gameData.CompAllH,
+						CoOpLeisure = gameData.InvestedCoH,
+						VsLeisure = gameData.InvestedMpH
+					};
+
+					double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+					try { ConcurrencyController?.ReportSample(elapsed, true); } catch { }
+					LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
+					return hltbData;
+				}
+				else
+				{
+					Logger.Warn($"No GameData find with {id}");
+					double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+					try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
+					LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
+					return null;
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				throw;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				Logger.Info($"GetGameData ERROR id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={(DateTime.UtcNow - startTime).TotalMilliseconds}ms");
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Updates the HLTB data for a user game entry.
+		/// </summary>
+		/// <param name="hltbDataUser">The user game data to update.</param>
+		/// <returns>Returns the updated <see cref="HltbDataUser"/>.</returns>
+		public async Task<HltbDataUser> UpdateGameData(HltbDataUser hltbDataUser)
+		{
+			try
+			{
+				HltbData hltbData = await GetGameData(hltbDataUser.Id);
+				hltbDataUser.GameHltbData = hltbData ?? hltbDataUser.GameHltbData;
+				return hltbDataUser;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				return null;
+			}
+		}
+
+
+		#region Search
+
+		/// <summary>
+		/// Retrieves the search URL from the website scripts.
+		/// </summary>
+		/// <returns>The search endpoint URL.</returns>
+		private async Task<string> GetSearchUrl()
+		{
+			return "/api/find";
+			if (!SearchUrl.IsNullOrEmpty() && !SearchUrl.Contains("error"))
+			{
+				return SearchUrl;
+			}
+
+			try
+			{
+				string url = UrlBase;
+
+				string response = null;
+				using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
+				{
+					try
+					{
+						using (var httpResp = await httpClient.GetAsync(url, cts.Token).ConfigureAwait(false))
+						{
+							if (!httpResp.IsSuccessStatusCode)
+							{
+								try { Logger.Warn($"HTTP {(int)httpResp.StatusCode} downloading {url}"); } catch { }
+								return "/api/s";
+							}
+
+							response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+						}
+					}
+					catch (TaskCanceledException)
+					{
+						try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {url}"); } catch { }
+						return "/api/s";
+					}
+					catch (Exception ex)
+					{
+						Common.LogError(ex, false, true, PluginDatabase.PluginName);
+						return "/api/s";
+					}
+				}
+
+				// Try to extract script URLs via optional HtmlAgilityPack helper (reflection). Fall back to regex if unavailable.
+				List<string> scriptUrls = ExtractScriptUrlsWithHap(response) ?? new List<string>();
+				if (scriptUrls.Count == 0)
+				{
+
+					var matches = MyRegex().Matches(response);
+					foreach (Match match in matches)
+					{
+						scriptUrls.Add(match.Groups[1].Value);
+					}
+				}
+
+				var ordered = scriptUrls.Where(s => s.Contains("_app-")).Concat(scriptUrls).Where(s => !string.IsNullOrEmpty(s)).Distinct();
+				foreach (string sUrl in ordered)
+				{
+					string scriptUrl = sUrl;
+					if (!scriptUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+					{
+						scriptUrl = UrlBase + scriptUrl;
+					}
+
+					string scriptContent = null;
+					using (var ctsScript = new CancellationTokenSource(ScriptDownloadTimeoutMs))
+					{
+						try
+						{
+							using (var scriptResp = await httpClient.GetAsync(scriptUrl, ctsScript.Token).ConfigureAwait(false))
+							{
+								if (!scriptResp.IsSuccessStatusCode)
+								{
+									try { Logger.Warn($"HTTP {(int)scriptResp.StatusCode} downloading {scriptUrl}"); } catch { }
+									continue;
+								}
+
+								scriptContent = await scriptResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+							}
+						}
+						catch (TaskCanceledException)
+						{
+							try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {scriptUrl}"); } catch { }
+							continue;
+						}
+						catch (Exception ex)
+						{
+							Common.LogError(ex, false, true, PluginDatabase.PluginName);
+							continue;
+						}
+					}
+
+					string pattern = "fetch\\s*\\(\\s*[\"']\\/api\\/([a-zA-Z0-9_\\/]+)[^\"']*[\"']\\s*,\\s*\\{[^}]*method:\\s*[\"']POST[\"'][^}]*\\}";
+					var searchMatch = Regex.Match(scriptContent, pattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+					if (searchMatch.Success)
+					{
+						string suffix = searchMatch.Groups[1].Value;
+						if (suffix.Contains("/"))
+						{
+							suffix = suffix.Split('/')[0];
+						}
+
+						if (suffix != "find")
+						{
+							lock (SearchUrlLock)
+							{
+								if (SearchUrl.IsNullOrEmpty())
+								{
+									SearchUrl = "/api/" + suffix;
+								}
+							}
+							return SearchUrl;
+						}
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+			}
+
+			return "/api/s";
+		}
 
 		/// <summary>
 		/// Retrieves the authentication token.
 		/// </summary>
-		/// <param name="apiEndpoint">API Endpoint for search</param>
 		/// <returns>The auth token.</returns>
-		private async Task<string> GetAuthToken(string apiEndpoint)
-        {
-            try
-            {
-                // Double-checked locking: quick snapshot first to avoid locking in common case
-                var snapshotToken = CachedAuthToken;
-                var snapshotExpiry = CachedAuthTokenExpiry;
-                if (!string.IsNullOrEmpty(snapshotToken) && DateTime.UtcNow < snapshotExpiry)
-                {
-                    return snapshotToken;
-                }
-
-                // Re-check under lock to avoid race with a concurrent writer
-                lock (AuthTokenSync)
-                {
-                    if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
-                    {
-                        return CachedAuthToken;
-                    }
-                }
-
-                List<HttpHeader> headers = new List<HttpHeader>
-                {
-                    new HttpHeader { Key = "Referer", Value = UrlBase }
-                };
-                string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
-                string response = null;
-                try
-                {
-                    using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
-                    using (var request = new HttpRequestMessage(HttpMethod.Get, url))
-                    {
-                        try { request.Headers.Add("Referer", UrlBase); } catch { }
-
-                        using (var resp = await httpClient.SendAsync(request, cts.Token).ConfigureAwait(false))
-                        {
-                            if (!resp.IsSuccessStatusCode)
-                            {
-                                try { Logger.Warn($"HTTP {(int)resp.StatusCode} downloading auth init {url}"); } catch { }
-                                return null;
-                            }
-
-                            response = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        }
-                    }
-                }
-                catch (TaskCanceledException)
-                {
-                    try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading auth init {url}"); } catch { }
-                    return null;
-                }
-                catch (Exception ex)
-                {
-                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                    return null;
-                }
-
-                var data = Serialization.FromJson<Dictionary<string, string>>(response);
-                if (data != null && data.TryGetValue("token", out string token))
-                {
-                    lock (AuthTokenSync)
-                    {
-                        // Final re-check before writing to shared fields
-                        if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
-                        {
-                            return CachedAuthToken;
-                        }
-                        CachedAuthToken = token;
-                        CachedAuthTokenExpiry = DateTime.UtcNow.AddSeconds(90);
-                    }
-                    return token;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-            }
-            return null;
-        }
-
-
-        /// <summary>
-        /// Searches for games on HowLongToBeat by name and platform.
-        /// </summary>
-        /// <param name="name">Game name to search for.</param>
-        /// <param name="platform">Optional platform filter.</param>
-        /// <returns>Returns a list of <see cref="HltbDataUser"/> matching the search.</returns>
-        private async Task<List<HltbDataUser>> Search(string name, string platform = "")
-        {
-            try
-            {
-                SearchResult searchResult = await ApiSearch(name, platform);
-
-                List<HltbDataUser> search = searchResult?.Data?.Select(x =>
-                    new HltbDataUser
-                    {
-                        Name = x.GameName,
-                        Id = x.GameId.ToString(),
-                        UrlImg = string.Format(UrlGameImg, x.GameImage),
-                        Url = string.Format(UrlGame, x.GameId),
-                        Platform = x.ProfilePlatform,
-                        GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
-                        GameHltbData = new HltbData
-                        {
-                            GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
-                            MainStoryClassic = x.CompMain,
-                            MainExtraClassic = x.CompPlus,
-                            CompletionistClassic = x.Comp100,
-                            SoloClassic = x.CompAll,
-                            CoOpClassic = x.InvestedCo,
-                            VsClassic = x.InvestedMp
-                        },
-                        NeedsDetails = !((x.CompMain > 0) || (x.CompAll > 0) || (x.CompPlus > 0) || (x.Comp100 > 0))
-                    }
-                )?.ToList() ?? new List<HltbDataUser>();
-
-                if (search.Count != 0)
-                {
-                    try
-                    {
-                        int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-                        await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "Search");
-                    }
-                    catch { }
-
-                    var tasks = search.Select(async x =>
-                    {
-                        bool acquiredGameSemaphore = false;
-                        try
-                        {
-                            try
-                            {
-                                try
-                                {
-                                    int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-                                    int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
-                                    int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
-                                    LogDebugVerbose($"Search: waiting semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
-                                }
-                                catch { }
-                                var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
-                                if (!acquired)
-                                {
-                                    Logger.Warn($"Search: timeout waiting for game data semaphore for id={x.Id}");
-                                    return;
-                                }
-                                acquiredGameSemaphore = true;
-                                try
-                                {
-                                    int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-                                    int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
-                                    int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
-                                    LogDebugVerbose($"Search: acquired semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
-                                }
-                                catch { }
-                            }
-                            catch (Exception ex)
-                            {
-                                Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                            }
-                            try
-                            {
-                                try
-                                {
-                                    bool hasCoreTimes = (x.GameHltbData != null) && (
-                                        (x.GameHltbData.MainStoryClassic > 0) ||
-                                        (x.GameHltbData.MainStoryAverage > 0) ||
-                                        (x.GameHltbData.MainStoryMedian > 0)
-                                    );
-
-                                    if (hasCoreTimes)
-                                    {
-                                        LogDebugVerbose($"Search: skipping GetGameData for id={x.Id} (search result has times)");
-                                        x.NeedsDetails = false;
-                                    }
-                                    else
-                                    {
-                                        using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
-                                        {
-                                            try
-                                            {
-                                                x.GameHltbData = await GetGameData(x.Id, ctsGame.Token);
-                                                x.NeedsDetails = false;
-                                            }
-                                            catch (OperationCanceledException)
-                                            {
-                                                Logger.Warn($"Timeout {GameDataDownloadTimeoutMs}ms getting game data for {x.Id}");
-                                                x.GameHltbData = null;
-                                            }
-                                        }
-                                    }
-                                }
-                                catch (Exception ex)
-                                {
-                                    Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                                    x.GameHltbData = null;
-                                }
-                            }
-                            finally
-                            {
-                                if (acquiredGameSemaphore)
-                                {
-                                    try
-                                    {
-                                        DynamicSemaphore.Release();
-                                    }
-                                    catch { }
-                                }
-                                LogDebugVerbose($"Search: released semaphore for id={x.Id}");
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                        }
-                    }).ToArray();
-
-                    await Task.WhenAll(tasks);
-                    try
-                    {
-                        LogDebugVerbose($"Search summary: persistentCacheHits={PersistentCacheHits}, inMemoryHits={InMemoryCacheHits}, pageFetches={PageFetches}");
-                    }
-                    catch { }
-                }
-                return search;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return new List<HltbDataUser>();
-            }
-        }
-
-        /// <summary>
-        /// Performs two search methods (normalized and original name) and merges results.
-        /// </summary>
-        /// <param name="name">Game name to search for.</param>
-        /// <param name="platform">Optional platform filter.</param>
-        /// <returns>Returns a list of <see cref="HltbSearch"/> with match percentages.</returns>
-        public async Task<List<HltbSearch>> SearchTwoMethod(string name, string platform = "", bool includeExtendedTimes = false)
-        {
-            // Apply manual aliases (exact normalized match) to support paired releases (e.g. Pokemon versions).
-            try
-            {
-                var settings = PluginDatabase?.PluginSettings?.Settings;
-                var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
-                var aliased = GameNameAliases.ApplyAlias(name, settings, userDataPath);
-                if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(name))
-                {
-                    LogDebugVerbose($"HLTB aliases: '{SafeStr(name)}' -> '{SafeStr(aliased)}'");
-                    name = aliased;
-                }
-            }
-            catch { }
-
-            string normalized = PlayniteTools.NormalizeGameName(name, true, true);
-
-            List<HltbDataUser> dataSearch = null;
-            List<HltbDataUser> dataSearchNormalized = null;
-
-            try
-            {
-                if (!string.IsNullOrEmpty(normalized) && !normalized.Equals(name, StringComparison.Ordinal))
-                {
-                    var t1 = Search(name, platform);
-                    var t2 = Search(normalized, platform);
-                    await Task.WhenAll(t1, t2).ConfigureAwait(false);
-                    dataSearch = t1.Result ?? new List<HltbDataUser>();
-                    dataSearchNormalized = t2.Result ?? new List<HltbDataUser>();
-                }
-                else
-                {
-                    dataSearch = await Search(name, platform);
-                    dataSearchNormalized = new List<HltbDataUser>();
-                }
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-                dataSearch = dataSearch ?? new List<HltbDataUser>();
-                dataSearchNormalized = dataSearchNormalized ?? new List<HltbDataUser>();
-            }
-
-            var dataSearchFinal = new List<HltbDataUser>();
-            if (dataSearch != null) dataSearchFinal.AddRange(dataSearch);
-            if (dataSearchNormalized != null) dataSearchFinal.AddRange(dataSearchNormalized);
-
-            dataSearchFinal = dataSearchFinal.GroupBy(x => x.Id).Select(x => x.First()).ToList();
-
-            string searchNameLower = (name ?? string.Empty).ToLower();
-            var results = dataSearchFinal
-                .Where(x => x != null)
-                .Select(x => new HltbSearch
-                {
-                    MatchPercent = Fuzz.Ratio(searchNameLower, (x.Name ?? string.Empty).ToLower()),
-                    Data = x
-                })
-                .OrderByDescending(x => x.MatchPercent)
-                .ToList();
-
-            if (includeExtendedTimes)
-            {
-                try
-                {
-                    const int maxDetails = 20;
-                    var targets = results
-                        .Select(r => r?.Data)
-                        .Where(x => x != null && !string.IsNullOrEmpty(x.Id))
-                        .Take(maxDetails)
-                        .ToList();
-
-                    if (targets.Count > 0)
-                    {
-                        try
-                        {
-                            int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-                            await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "SearchTwoMethod+Details");
-                        }
-                        catch { }
-
-                        var tasks = targets.Select(async x =>
-                        {
-                            bool acquiredGameSemaphore = false;
-                            try
-                            {
-                                var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
-                                if (!acquired)
-                                {
-                                    return;
-                                }
-                                acquiredGameSemaphore = true;
-
-                                using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
-                                {
-                                    try
-                                    {
-                                        var details = await GetGameData(x.Id, ctsGame.Token);
-                                        if (details != null)
-                                        {
-                                            x.GameHltbData = details;
-                                            x.NeedsDetails = false;
-                                        }
-                                    }
-                                    catch (OperationCanceledException)
-                                    {
-                                        // Ignore timeout; keep basic search data
-                                    }
-                                    catch
-                                    {
-                                        // Ignore; keep basic search data
-                                    }
-                                }
-                            }
-                            finally
-                            {
-                                if (acquiredGameSemaphore)
-                                {
-                                    try { DynamicSemaphore.Release(); } catch { }
-                                }
-                            }
-                        }).ToArray();
-
-                        await Task.WhenAll(tasks).ConfigureAwait(false);
-                    }
-                }
-                catch
-                {
-                    // Best-effort enrichment; never fail the whole search.
-                }
-            }
-
-            return results;
-        }
-
-        /// <summary>
-        /// Performs an API search for games.
-        /// </summary>
-        /// <param name="name">Game name to search for.</param>
-        /// <param name="platform">Optional platform filter.</param>
-        /// <returns>Returns a <see cref="SearchResult"/> object.</returns>
-        private async Task<SearchResult> ApiSearch(string name, string platform = "")
-        {
-            try { EnsureMonitoringStarted(); } catch { }
-            int GetSearchTarget()
-            {
-                try
-                {
-                    int baseTarget = MaxParallelSearches;
-                    lock (BackoffSync)
-                    {
-                        if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
-                        {
-                            return Math.Min(baseTarget, SearchBackoffLimit);
-                        }
-                    }
-                    return baseTarget;
-                }
-                catch
-                {
-                    return SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
-                }
-            }
-
-            try
-            {
-                string cacheKey = (name ?? string.Empty) + "|" + (platform ?? string.Empty);
-                if (SearchCache.TryGetValue(cacheKey, out SearchResult cachedResult))
-                {
-                    try { LogDebugVerbose($"ApiSearch cache hit for '{name}' platform='" + platform + "'"); } catch { }
-                    return cachedResult;
-                }
-
-                List<HttpHeader> httpHeaders = new List<HttpHeader>
-                {
-                    new HttpHeader { Key = "User-Agent", Value = Web.UserAgent },
-                    new HttpHeader { Key = "Origin", Value = UrlBase },
-                    new HttpHeader { Key = "Referer", Value = UrlBase }
-                };
-
-                SearchParam searchParam = new SearchParam
-                {
-                    SearchTerms = name.Split(' ').ToList(),
-                    SearchOptions = new SearchOptions { Games = new Games { Platform = platform } }
-                };
-
-                SearchResult searchResult = null;
-                string serializedBody = Serialization.ToJson(searchParam);
-                string searchUrl = await GetSearchUrl();
-                bool tokenReused = !string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry;
-                string token = await GetAuthToken(searchUrl);
-                if (!token.IsNullOrEmpty())
-                {
-                    httpHeaders.Add(new HttpHeader { Key = "x-auth-token", Value = token });
-                }
-
-                bool acquired = false;
-                try
-                {
-                    try
-                    {
-                        try
-                        {
-                            int target = GetSearchTarget();
-                            await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, target, SearchConcurrencySync, "ApiSearch+Initial");
-                        }
-                        catch { }
-
-                        try
-                        {
-                            int targetLog = GetSearchTarget();
-                            int availableLog = SearchSemaphore?.CurrentCount ?? 0;
-                            int inFlightLog = Math.Max(0, targetLog - availableLog);
-                            LogDebugVerbose($"ApiSearch: waiting search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
-                        }
-                        catch { }
-                        bool waitOk = true;
-                        if (SearchSemaphore != null)
-                        {
-                            waitOk = await SearchSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
-                        }
-                        if (!waitOk)
-                        {
-                            Logger.Warn($"ApiSearch: timeout waiting search semaphore for '{name}'");
-                            return null;
-                        }
-                        acquired = true;
-                        try
-                        {
-                            int targetLog = GetSearchTarget();
-                            int availableLog = SearchSemaphore?.CurrentCount ?? 0;
-                            int inFlightLog = Math.Max(0, targetLog - availableLog);
-                            LogDebugVerbose($"ApiSearch: acquired search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
-                        }
-                        catch { }
-                    }
-                    catch (Exception ex)
-                    {
-                        Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                    }
-
-                    var sw = Stopwatch.StartNew();
-                    // Use local helper to avoid dependency on optional CommonPluginsShared submodule.
-                    // Allow the POST to be cancelled/timeout independently of the shared HttpClient timeout by using a bounded CTS.
-                    (string body, int status, string retry) postResult;
-                    using (var postCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-                    {
-                        postResult = await PostJsonWithSharedClientWithStatus(UrlBase + searchUrl, serializedBody, httpHeaders, postCts.Token);
-                    }
-                    sw.Stop();
-                    string json = postResult.body ?? string.Empty;
-                    int statusCode = postResult.status;
-                    string retryAfterHeader = postResult.retry;
-
-                    try
-                    {
-                        if (statusCode == 429)
-                        {
-                            int backoffSeconds = 30;
-                            if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsedSeconds))
-                            {
-                                backoffSeconds = Math.Max(1, parsedSeconds);
-                            }
-
-                            lock (BackoffSync)
-                            {
-                                int newLimit = Math.Max(1, CurrentSearchLimit / 2);
-                                SearchBackoffLimit = newLimit;
-                                SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
-                            }
-
-                            Logger.Warn($"ApiSearch: received 429 for '{name}'. Immediate backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
-                        }
-                    }
-                    catch { }
-
-                    try
-                    {
-                        try
-                        {
-                            RecentSearchSamples.Enqueue(sw.ElapsedMilliseconds);
-                            while (RecentSearchSamples.Count > RecentSamplesWindow)
-                            {
-                                RecentSearchSamples.TryDequeue(out _);
-                            }
-                        }
-                        catch { }
-
-                        try
-                        {
-                            RecentSearchStatusCodes.Enqueue(statusCode);
-                            while (RecentSearchStatusCodes.Count > RecentStatusWindow)
-                            {
-                                RecentSearchStatusCodes.TryDequeue(out _);
-                            }
-                        }
-                        catch { }
-
-                        LogDebugVerbose($"ApiSearch elapsed={sw.ElapsedMilliseconds}ms tokenReused={tokenReused} status={statusCode}");
-                    }
-                    catch { }
-
-                    _ = Serialization.TryFromJson(json, out searchResult);
-
-                    try
-                    {
-                        bool successSample = searchResult != null && searchResult.Data != null && statusCode != 429;
-                        SearchConcurrencyController?.ReportSample(sw.ElapsedMilliseconds, successSample);
-                    }
-                    catch { }
-
-                    int postLockPendingConsume = 0;
-                    try
-                    {
-                        var codes = RecentSearchStatusCodes.ToArray();
-                        if (codes.Length > 0)
-                        {
-                            int count429 = codes.Count(c => c == 429);
-                            double frac = count429 / (double)codes.Length;
-                            if (count429 >= 3 && frac >= 0.05)
-                            {
-                                lock (BackoffSync)
-                                {
-                                    if (SearchBackoffLimit == 0 || DateTime.UtcNow >= SearchBackoffUntil)
-                                    {
-                                        int newLimit = Math.Max(1, CurrentSearchLimit / 2);
-                                        SearchBackoffLimit = newLimit;
-
-                                        int backoffSeconds = 30;
-                                        try
-                                        {
-                                            if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsed))
-                                            {
-                                                backoffSeconds = Math.Max(1, parsed);
-                                            }
-                                        }
-                                        catch { }
-                                        SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
-                                        Logger.Warn($"ApiSearch: detected elevated 429 rate ({count429}/{codes.Length}). Applying temporary search backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
-                                        try
-                                        {
-                                            int currentLimitSnapshot;
-                                            lock (SearchConcurrencySync)
-                                            {
-                                                currentLimitSnapshot = CurrentSearchLimit;
-                                            }
-                                            int diff = SearchBackoffLimit - currentLimitSnapshot;
-                                            if (diff > 0)
-                                            {
-                                                try { SearchSemaphore.Release(diff); } catch { }
-                                                lock (SearchConcurrencySync)
-                                                {
-                                                    CurrentSearchLimit = SearchBackoffLimit;
-                                                }
-                                            }
-                                            else if (diff < 0)
-                                            {
-                                                postLockPendingConsume = -diff;
-                                            }
-                                        }
-                                        catch { }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    catch { }
-
-                    try
-                    {
-                        if (postLockPendingConsume > 0)
-                        {
-                            int backoffSnapshot;
-                            lock (BackoffSync)
-                            {
-                                backoffSnapshot = SearchBackoffLimit;
-                            }
-
-                            await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, backoffSnapshot, SearchConcurrencySync, "ApiSearch+PostBackoff");
-                        }
-                    }
-                    catch { }
-
-                    try
-                    {
-                        if (searchResult != null)
-                        {
-                            SearchCache.TryAdd(cacheKey, searchResult);
-                        }
-                    }
-                    catch { }
-
-                    return searchResult;
-                }
-                finally
-                {
-                    if (acquired)
-                    {
-                        try
-                        {
-                            SearchSemaphore.Release();
-                            LogDebugVerbose($"ApiSearch: released search semaphore for '{name}'");
-                        }
-                        catch { }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Opens a selection window for the user to choose the correct game data.
-        /// </summary>
-        /// <param name="game">The Playnite game object.</param>
-        /// <param name="data">Optional list of search results.</param>
-        /// <returns>Returns a <see cref="GameHowLongToBeat"/> object if a selection is made, otherwise null.</returns>
-        public GameHowLongToBeat SearchData(Game game, List<HltbDataUser> data = null)
-        {
-            Common.LogDebug(true, $"Search data for {game.Name}");
-            if (API.Instance.ApplicationInfo.Mode == ApplicationMode.Desktop)
-            {
-                HowLongToBeatSelect ViewExtension = null;
-                _ = Application.Current.Dispatcher.BeginInvoke((Action)delegate
-                {
-                    ViewExtension = new HowLongToBeatSelect(game, data);
-                    Window windowExtension = PlayniteUiHelper.CreateExtensionWindow(ResourceProvider.GetString("LOCSelection") + " - " + game.Name + " - " + (game.Source?.Name ?? "Playnite"), ViewExtension);
-                    _ = windowExtension.ShowDialog();
-                }).Wait();
-
-                if (ViewExtension.GameHowLongToBeat?.Items.Count > 0)
-                {
-                    return ViewExtension.GameHowLongToBeat;
-                }
-            }
-            return null;
-        }
-
-        public HltbDataUser SearchDataAuto(string gameName, string platform = "")
-        {
-            string traceId = null;
-            try
-            {
-                if (string.IsNullOrEmpty(gameName))
-                {
-                    return null;
-                }
-
-                // Apply manual aliases (exact normalized match) early so all subsequent matching uses the aliased title.
-                try
-                {
-                    var settings = PluginDatabase?.PluginSettings?.Settings;
-                    var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
-                    var aliased = GameNameAliases.ApplyAlias(gameName, settings, userDataPath);
-                    if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(gameName))
-                    {
-                        LogDebugVerbose($"HLTB aliases: '{SafeStr(gameName)}' -> '{SafeStr(aliased)}'");
-                        gameName = aliased;
-                    }
-                }
-                catch { }
-
-                traceId = Guid.NewGuid().ToString("N").Substring(0, 8);
-
-                var hltbSettings = PluginDatabase?.PluginSettings?.Settings;
-
-                if (IsVerboseLoggingEnabled)
-                {
-                    try
-                    {
-                        Logger.Debug($"SearchDataAuto[{traceId}]: start name='{SafeStr(gameName)}' platform='{SafeStr(platform)}' UseMatchValue={hltbSettings?.UseMatchValue} MatchValue={hltbSettings?.MatchValue}");
-                    }
-                    catch { }
-                }
-
-                List<HltbSearch> results = null;
-                bool gotResults = false;
-                try
-                {
-                    // 1) First pass: fast search (no details fetch)
-                    gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 15000, Logger);
-                    if (!gotResults)
-                    {
-                        if (IsVerboseLoggingEnabled)
-                        {
-                            try { Logger.Warn($"SearchDataAuto[{traceId}]: SearchTwoMethod timed out after 15000ms; retrying once"); } catch { }
-                        }
-
-                        gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 30000, Logger);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    if (IsVerboseLoggingEnabled)
-                    {
-                        try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
-                    }
-                    results = null;
-                }
-
-                if (!gotResults)
-                {
-                    if (IsVerboseLoggingEnabled)
-                    {
-                        try { Logger.Debug($"SearchDataAuto[{traceId}]: no results (timeout)"); } catch { }
-                    }
-                    return null;
-                }
-
-                if (results == null || results.Count == 0)
-                {
-                    if (IsVerboseLoggingEnabled)
-                    {
-                        try { Logger.Debug($"SearchDataAuto[{traceId}]: no results"); } catch { }
-                    }
-                    return null;
-                }
-
-                if (IsVerboseLoggingEnabled)
-                {
-                    try
-                    {
-                        Logger.Debug($"SearchDataAuto[{traceId}]: results count={results.Count}");
-                        int take = Math.Min(8, results.Count);
-                        for (int i = 0; i < take; i++)
-                        {
-                            var r = results[i];
-                            var d = r?.Data;
-                            long ttb = 0;
-                            bool hasAnyTime = false;
-                            try
-                            {
-                                ttb = d?.GameHltbData?.TimeToBeat ?? 0;
-                                hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
-                            }
-                            catch { }
-
-                            Logger.Debug($"SearchDataAuto[{traceId}]: candidate[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
-                        }
-                    }
-                    catch { }
-                }
-
-                try
-                {
-                    var nQuery = PlayniteTools.NormalizeGameName(gameName ?? string.Empty, true, true);
-                    if (!string.IsNullOrEmpty(nQuery))
-                    {
-                        var exact = results
-                            .Where(r => r?.Data != null)
-                            .Select(r => new { r.MatchPercent, Data = r.Data, Norm = PlayniteTools.NormalizeGameName(r.Data?.Name ?? string.Empty, true, true) })
-                            .Where(x => !string.IsNullOrEmpty(x.Norm) && x.Norm.IsEqual(nQuery))
-                            .OrderByDescending(x => x.MatchPercent)
-                            .FirstOrDefault();
-
-                        if (exact?.Data != null)
-                        {
-                            if (hltbSettings != null && hltbSettings.UseMatchValue && exact.MatchPercent < hltbSettings.MatchValue && exact.MatchPercent < 98)
-                            {
-                                if (IsVerboseLoggingEnabled)
-                                {
-                                    try { Logger.Debug($"SearchDataAuto[{traceId}]: exact normalized match rejected by MatchValue score={exact.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-                                }
-                                return null;
-                            }
-
-                            if (IsVerboseLoggingEnabled)
-                            {
-                                try { Logger.Debug($"SearchDataAuto[{traceId}]: selected exact normalized match id={SafeStr(exact.Data?.Id)} title='{SafeStr(exact.Data?.Name)}' score={exact.MatchPercent}"); } catch { }
-                            }
-
-                            return exact.Data;
-                        }
-                    }
-                }
-                catch { }
-
-                var best = results[0];
-                if (best?.Data == null)
-                {
-                    if (IsVerboseLoggingEnabled)
-                    {
-                        try { Logger.Debug($"SearchDataAuto[{traceId}]: best result had null data"); } catch { }
-                    }
-                    return null;
-                }
-
-                try
-                {
-                    if (hltbSettings != null && hltbSettings.UseMatchValue && best.MatchPercent < hltbSettings.MatchValue)
-                    {
-                        if (best.MatchPercent >= 98)
-                        {
-                            if (IsVerboseLoggingEnabled)
-                            {
-                                try { Logger.Debug($"SearchDataAuto[{traceId}]: best below MatchValue but accepted via near-perfect safety net score={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-                            }
-                            return best.Data;
-                        }
-
-                        if (IsVerboseLoggingEnabled)
-                        {
-                            try { Logger.Debug($"SearchDataAuto[{traceId}]: rejected by MatchValue bestScore={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-                        }
-                        return null;
-                    }
-                }
-                catch { }
-
-                // 2) Ambiguity handling: if multiple top results are close in score,
-                // fetch details for top candidates and prefer one that actually has times.
-                try
-                {
-                    if (results.Count > 1)
-                    {
-                        var second = results[1];
-                        bool ambiguous = false;
-                        try
-                        {
-                            ambiguous = (best.MatchPercent < 100 && second != null && (best.MatchPercent - second.MatchPercent) <= 3);
-                        }
-                        catch { }
-
-                        if (IsVerboseLoggingEnabled)
-                        {
-                            try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguity check best={best.MatchPercent} second={second?.MatchPercent} ambiguous={ambiguous}"); } catch { }
-                        }
-
-                        if (ambiguous)
-                        {
-                            List<HltbSearch> enriched = null;
-                            try
-                            {
-                                enriched = TaskHelpers.RunSyncWithTimeout(() => SearchTwoMethod(gameName, platform, includeExtendedTimes: true), 20000);
-                            }
-                            catch (Exception ex)
-                            {
-                                if (IsVerboseLoggingEnabled)
-                                {
-                                    try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: enrichment SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
-                                }
-                                enriched = null;
-                            }
-
-                            if (enriched != null && enriched.Count > 0)
-                            {
-                                if (IsVerboseLoggingEnabled)
-                                {
-                                    try
-                                    {
-                                        Logger.Debug($"SearchDataAuto[{traceId}]: enriched count={enriched.Count}");
-                                        int take = Math.Min(8, enriched.Count);
-                                        for (int i = 0; i < take; i++)
-                                        {
-                                            var r = enriched[i];
-                                            var d = r?.Data;
-                                            long ttb = 0;
-                                            bool hasAnyTime = false;
-                                            try
-                                            {
-                                                ttb = d?.GameHltbData?.TimeToBeat ?? 0;
-                                                hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
-                                            }
-                                            catch { }
-
-                                            Logger.Debug($"SearchDataAuto[{traceId}]: enriched[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
-                                        }
-                                    }
-                                    catch { }
-                                }
-
-                                var withTimes = enriched
-                                    .Where(r => r?.Data?.GameHltbData != null)
-                                    .Where(r =>
-                                    {
-                                        try
-                                        {
-                                            return r.Data.GameHltbData.TimeToBeat > 0 || r.Data.GameHltbData.MainStoryClassic > 0 || r.Data.GameHltbData.MainExtraClassic > 0 || r.Data.GameHltbData.CompletionistClassic > 0 || r.Data.GameHltbData.SoloClassic > 0;
-                                        }
-                                        catch { return false; }
-                                    })
-                                    .OrderByDescending(r => r.MatchPercent)
-                                    .FirstOrDefault();
-
-                                if (withTimes?.Data != null)
-                                {
-                                    if (hltbSettings != null && hltbSettings.UseMatchValue && withTimes.MatchPercent < hltbSettings.MatchValue && withTimes.MatchPercent < 98)
-                                    {
-                                        if (IsVerboseLoggingEnabled)
-                                        {
-                                            try { Logger.Debug($"SearchDataAuto[{traceId}]: enriched withTimes rejected by MatchValue score={withTimes.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-                                        }
-                                        return null;
-                                    }
-
-                                    if (IsVerboseLoggingEnabled)
-                                    {
-                                        try { Logger.Debug($"SearchDataAuto[{traceId}]: selected enriched withTimes id={SafeStr(withTimes.Data?.Id)} title='{SafeStr(withTimes.Data?.Name)}' score={withTimes.MatchPercent}"); } catch { }
-                                    }
-                                    return withTimes.Data;
-                                }
-
-                                var bestEnriched = enriched[0];
-                                if (bestEnriched?.Data != null)
-                                {
-                                    if (hltbSettings != null && hltbSettings.UseMatchValue && bestEnriched.MatchPercent < hltbSettings.MatchValue && bestEnriched.MatchPercent < 98)
-                                    {
-                                        if (IsVerboseLoggingEnabled)
-                                        {
-                                            try { Logger.Debug($"SearchDataAuto[{traceId}]: bestEnriched rejected by MatchValue score={bestEnriched.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-                                        }
-                                        return null;
-                                    }
-
-                                    if (IsVerboseLoggingEnabled)
-                                    {
-                                        try { Logger.Debug($"SearchDataAuto[{traceId}]: selected bestEnriched id={SafeStr(bestEnriched.Data?.Id)} title='{SafeStr(bestEnriched.Data?.Name)}' score={bestEnriched.MatchPercent}"); } catch { }
-                                    }
-                                    return bestEnriched.Data;
-                                }
-                            }
-
-                            if (best.MatchPercent >= 98)
-                            {
-                                if (IsVerboseLoggingEnabled)
-                                {
-                                    try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguous but fell back to near-perfect best score={best.MatchPercent} id={SafeStr(best.Data?.Id)}"); } catch { }
-                                }
-                                return best.Data;
-                            }
-                        }
-                    }
-                }
-                catch { }
-
-                if (IsVerboseLoggingEnabled)
-                {
-                    try { Logger.Debug($"SearchDataAuto[{traceId}]: selected best (default) id={SafeStr(best.Data?.Id)} title='{SafeStr(best.Data?.Name)}' score={best.MatchPercent}"); } catch { }
-                }
-
-                return best.Data;
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, true, PluginDatabase?.PluginName); } catch { }
-                return null;
-            }
-        }
-
-        #endregion
-
-        #region user account
-
-        /// <summary>
-        /// Checks if the user is currently logged in to HowLongToBeat (async).
-        /// </summary>
-        /// <returns>True if logged in, otherwise false.</returns>
-        public async Task<bool> GetIsUserLoggedInAsync()
-        {
-            // Avoid getting stuck in a "logged out" state if this method is called before PluginDatabase is loaded.
-            // Use stored cookies directly to check the current session.
-            try
-            {
-                var now = DateTime.UtcNow;
-                if (lastLoginCheckResult != null)
-                {
-                    var ttl = lastLoginCheckResult == true ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(1);
-                    if (now - lastLoginCheckUtc < ttl)
-                    {
-                        return lastLoginCheckResult.Value;
-                    }
-                }
-
-                int userId = await GetUserId().ConfigureAwait(false);
-                UserId = userId;
-                IsConnected = userId != 0;
-
-                lastLoginCheckUtc = now;
-                lastLoginCheckResult = userId != 0;
-
-                if (IsVerboseLoggingEnabled)
-                {
-                    Logger.Debug($"HLTB Auth: GetIsUserLoggedInAsync userId={userId} IsConnected={IsConnected}");
-                }
-
-                return userId != 0;
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-                UserId = 0;
-                IsConnected = false;
-                lastLoginCheckUtc = DateTime.UtcNow;
-                lastLoginCheckResult = false;
-                return false;
-            }
-        }
-
-        public bool GetIsUserLoggedIn()
-        {
-            try
-            {
-                return Task.Run(() => GetIsUserLoggedInAsync()).Result;
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Initiates the login process for HowLongToBeat.
-        /// </summary>
-        public void Login()
-        {
-            // Use a DispatcherOperation so we can attach the Completed handler cleanly
-            System.Windows.Threading.DispatcherOperation op = null;
-
-            try
-            {
-                op = Application.Current.Dispatcher.BeginInvoke((Action)delegate
-                {
-                    Logger.Info("Login()");
-
-                    bool cookiesCaptured = false;
-
-                    WebViewSettings settings = new WebViewSettings
-                    {
-                        JavaScriptEnabled = true,
-                        WindowHeight = 670,
-                        WindowWidth = 490,
-                        UserAgent = Web.UserAgent
-                    };
-
-                    using (IWebView webView = API.Instance.WebViews.CreateView(settings))
-                    {
-                        webView.LoadingChanged += (s, e) =>
-                        {
-                            try
-                            {
-                                Common.LogDebug(true, $"NavigationChanged - {webView.GetCurrentAddress()}");
-
-                                if (!cookiesCaptured && webView.GetCurrentAddress().StartsWith(UrlBase + "/user/"))
-                                {
-                                    cookiesCaptured = true;
-                                    UserLogin = WebUtility.HtmlDecode(webView.GetCurrentAddress().Replace(UrlBase + "/user/", string.Empty));
-                                    IsConnected = true;
-
-                                    // Give the embedded WebView a moment to commit cookies.
-                                    FireAndForget(Task.Run(async () =>
-                                    {
-                                        try
-                                        {
-                                            await Task.Delay(1000).ConfigureAwait(false);
-                                        }
-                                        catch { }
-
-                                        try
-                                        {
-                                            await Application.Current.Dispatcher.InvokeAsync(() =>
-                                            {
-                                                try
-                                                {
-                                                    List<HttpCookie> cookies = CookiesTools.GetWebCookies(deleteCookies: false, webView: webView);
-                                                    bool saved = CookiesTools.SetStoredCookies(cookies);
-                                                    Logger.Info($"HLTB Auth: captured cookies from login webview count={cookies?.Count ?? 0} saved={saved}");
-                                                    LogCookieSummary("login captured", cookies);
-
-                                                    // Invalidate cached login check so next calls re-check if needed.
-                                                    lastLoginCheckResult = null;
-                                                    lastLoginCheckUtc = DateTime.MinValue;
-                                                }
-                                                catch ( Exception ex)
-                                                {
-                                                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                                                }
-                                                finally
-                                                {
-                                                    try { webView.Close(); } catch { }
-                                                }
-                                            });
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-                                            try
-                                            {
-                                                var closeOp = Application.Current.Dispatcher.BeginInvoke((Action)(() => { try { webView.Close(); } catch { } }));
-                                                try { FireAndForget(closeOp?.Task, "login close webview (BeginInvoke)"); } catch { }
-                                            }
-                                            catch { }
-                                        }
-                                    }), "login captured");
-
-                                    // (task is fire-and-forget intentionally)
-
-                                    return;
-                                }
-                            }
-                            catch { }
-                        };
-
-                        IsConnected = false;
-                        webView.Navigate(UrlLogOut);
-                        _ = webView.OpenDialog();
-                    }
-                });
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-            }
-
-            try
-            {
-                if (op != null)
-                {
-                    op.Completed += (s, e) =>
-                    {
-                        try
-                        {
-                            if ((bool)IsConnected)
-                            {
-                                _ = Application.Current.Dispatcher?.BeginInvoke((Action)delegate
-                                {
-                                    try
-                                    {
-                                        PluginDatabase.PluginSettings.Settings.UserLogin = UserLogin;
-
-                                        PluginDatabase.Plugin.SavePluginSettings(PluginDatabase.PluginSettings.Settings);
-
-                                        FireAndForget(Task.Run(async () =>
-                                        {
-                                            try { UserId = await GetUserId().ConfigureAwait(false); } catch { }
-                                            try { PluginDatabase.RefreshUserData(); } catch { }
-                                        }), "post-login refresh");
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                                    }
-                                });
-                            }
-                        }
-                        catch { }
-                    };
-                }
-            }
-            catch { }
-        }
-
-        /// <summary>
-        /// Retrieves the user ID of the currently logged-in user.
-        /// </summary>
-        /// <returns>User ID as integer, or 0 if not logged in.</returns>
-        private async Task<int> GetUserId()
-        {
-            try
-            {
-                List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-                LogCookieSummary("GetUserId stored", cookies);
-
-                if (cookies == null || cookies.Count == 0)
-                {
-                    try { Logger.Info("HLTB Auth: no stored cookies available"); } catch { }
-                }
-                string response = await Web.DownloadPageText(UrlUser, cookies);
-                dynamic t = Serialization.FromJson<dynamic>(response);
-
-                int userId = response == "{}" ? 0 : t?.data[0]?.user_id ?? 0;
-                if (IsVerboseLoggingEnabled)
-                {
-                    Logger.Debug($"HLTB Auth: GetUserId responseLen={response?.Length ?? 0} userId={userId}");
-                }
-
-                return userId;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false);
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Retrieves the list of games for the current user.
-        /// </summary>
-        /// <returns>Returns a <see cref="UserGamesList"/> object.</returns>
-        private async Task<UserGamesList> GetUserGamesList()
-        {
-            try
-            {
-                List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-
-                UserGamesListParam userGamesListParam = new UserGamesListParam { UserId = UserId };
-                string payload = Serialization.ToJson(userGamesListParam);
-
-                string json = await PostJson(string.Format(UrlUserGamesList, UserId), payload, cookies);
-                _ = Serialization.TryFromJson(json, out UserGamesList userGamesList);
-
-                return userGamesList;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Converts a <see cref="GamesList"/> entry to a <see cref="TitleList"/>.
-        /// </summary>
-        /// <param name="gamesList">The games list entry.</param>
-        /// <returns>Returns a <see cref="TitleList"/> object.</returns>
-        private TitleList GetTitleList(GamesList gamesList)
-        {
-            try
-            {
-                _ = DateTime.TryParse(gamesList.DateUpdated, out DateTime lastUpdate);
-                _ = DateTime.TryParse(gamesList.DateComplete, out DateTime completion);
-                _ = DateTime.TryParse(gamesList.DateStart, out DateTime dateStart);
-                DateTime? completionFinal = null;
-                if (completion != default)
-                {
-                    completionFinal = completion;
-                }
-
-                TitleList titleList = new TitleList
-                {
-                    UserGameId = gamesList.Id.ToString(),
-                    GameName = gamesList.CustomTitle,
-                    Platform = gamesList.Platform,
-                    Id = gamesList.GameId.ToString(),
-                    CurrentTime = gamesList.InvestedPro,
-                    IsReplay = gamesList.PlayCount == 2,
-                    IsRetired = gamesList.ListRetired == 1,
-                    Storefront = gamesList.PlayStorefront,
-                    StartDate = dateStart,
-                    LastUpdate = lastUpdate,
-                    Completion = completionFinal,
-                    HltbUserData = new HltbData
-                    {
-                        GameType = gamesList.GameType.IsEqual("game") ? GameType.Game : gamesList.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
-                        MainStoryClassic = gamesList.CompMain,
-                        MainExtraClassic = gamesList.CompPlus,
-                        CompletionistClassic = gamesList.Comp100,
-                        SoloClassic = 0,
-                        CoOpClassic = gamesList.InvestedCo,
-                        VsClassic = gamesList.InvestedMp
-                    },
-                    GameStatuses = new List<GameStatus>()
-                };
-
-                if (gamesList.ListBacklog == 1)
-                {
-                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Backlog });
-                }
-
-                if (gamesList.ListComp == 1)
-                {
-                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Completed });
-                }
-
-                if (gamesList.ListCustom == 1)
-                {
-                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.CustomTab });
-                }
-
-                if (gamesList.ListPlaying == 1)
-                {
-                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Playing });
-                }
-
-                if (gamesList.ListReplay == 1)
-                {
-                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Replays });
-                }
-
-                if (gamesList.ListRetired == 1)
-                {
-                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Retired });
-                }
-
-                return titleList;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Retrieves the edit data for a specific user game entry.
-        /// </summary>
-        /// <param name="gameName">The name of the game.</param>
-        /// <param name="userGameId">The user game ID.</param>
-        /// <returns>Returns an <see cref="EditData"/> object.</returns>
-        public async Task<EditData> GetEditData(string gameName, string userGameId)
-        {
-            Logger.Info($"GetEditData({gameName}, {userGameId})");
-            try
-            {
-                List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-
-                string response = await Web.DownloadStringData(string.Format(UrlPostDataEdit, userGameId), cookies);
-                if (string.IsNullOrEmpty(response) || !response.Contains("__NEXT_DATA__"))
-                {
-                    Logger.Warn($"No EditData for {gameName} - {userGameId}");
-                    return null;
-                }
-
-                string jsonData = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
-                _ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
-                if (parseEx != null)
-                {
-                    Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
-                }
-
-                return next_data?.Props?.PageProps?.EditData?.UserId != null
-                    ? next_data.Props.PageProps.EditData
-                    : throw new Exception($"No EditData find for {gameName} - {userGameId}");
-            }
-            catch (Exception ex)
-            {
-                if (IsFirst)
-                {
-                    IsFirst = false;
-                    return await GetEditData(gameName, userGameId);
-                }
-                else
-                {
-                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                    return null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Loads user stats from the local file.
-        /// </summary>
-        /// <returns>Returns a <see cref="HltbUserStats"/> object.</returns>
-        public HltbUserStats LoadUserData()
-        {
-            string pathHltbUserStats = Path.Combine(PluginDatabase.Plugin.GetPluginUserDataPath(), "HltbUserStats.json");
-            HltbUserStats hltbDataUser = new HltbUserStats();
-
-            if (File.Exists(pathHltbUserStats))
-            {
-                try
-                {
-                    if (!Serialization.TryFromJsonFile(pathHltbUserStats, out hltbDataUser))
-                    {
-                        return new HltbUserStats();
-                    }
-                    hltbDataUser.TitlesList = hltbDataUser.TitlesList.Where(x => x != null).ToList();
-                }
-                catch (Exception ex)
-                {
-                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                }
-            }
-
-            return hltbDataUser;
-        }
-
-        /// <summary>
-        /// Retrieves the user data from HowLongToBeat (async).
-        /// </summary>
-        /// <returns>Returns a <see cref="HltbUserStats"/> object, or null if not logged in.</returns>
-        public async Task<HltbUserStats> GetUserDataAsync()
-        {
-            if (await GetIsUserLoggedInAsync().ConfigureAwait(false))
-            {
-                HltbUserStats hltbUserStats = new HltbUserStats
-                {
-                    Login = UserLogin.IsNullOrEmpty() ? PluginDatabase.Database.UserHltbData.Login : UserLogin,
-                    UserId = (UserId == 0) ? PluginDatabase.Database.UserHltbData.UserId : UserId,
-                    TitlesList = new List<TitleList>()
-                };
-
-                UserGamesList userGamesList = null;
-                try { userGamesList = await GetUserGamesList().ConfigureAwait(false); } catch { userGamesList = null; }
-                if (userGamesList == null)
-                {
-                    return null;
-                }
-
-                try
-                {
-                    userGamesList.Data.GamesList.ForEach(x =>
-                    {
-                        TitleList titleList = GetTitleList(x);
-                        hltbUserStats.TitlesList.Add(titleList);
-                    });
-                }
-                catch (Exception ex)
-                {
-                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                    return null;
-                }
-
-                return hltbUserStats;
-            }
-            else
-            {
-                API.Instance.Notifications.Add(new NotificationMessage(
-                    $"{PluginDatabase.PluginName}-Import-Error",
-                    PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
-                    NotificationType.Error,
-                    () => PluginDatabase.Plugin.OpenSettingsView()
-                ));
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Synchronous wrapper for backwards compatibility; runs async method on thread-pool.
-        /// </summary>
-        public HltbUserStats GetUserData()
-        {
-            try
-            {
-                var task = Task.Run(() => GetUserDataAsync());
-                if (!task.Wait(15000))
-                {
-                    try { Logger.Warn("GetUserData timed out"); } catch { }
-                    return null;
-                }
-                return task.Result;
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Finds the existing user game ID for a given game ID (async).
-        /// </summary>
-        public async Task<string> FindIdExistingAsync(string gameId)
-        {
-            try
-            {
-                var ug = await GetUserGamesList().ConfigureAwait(false);
-                return ug?.Data?.GamesList?.Find(x => x.GameId.ToString().IsEqual(gameId))?.Id.ToString() ?? null;
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Synchronous wrapper for backwards compatibility.
-        /// </summary>
-        public string FindIdExisting(string gameId)
-        {
-            try
-            {
-                var task = Task.Run(() => FindIdExistingAsync(gameId));
-                if (!task.Wait(15000))
-                {
-                    try { Logger.Warn($"FindIdExisting({gameId}) timed out"); } catch { }
-                    return null;
-                }
-                return task.Result;
-            }
-            catch (Exception ex)
-            {
-                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Synchronous helper: get TitleList for a specific game id from user data.
-        /// </summary>
-        public TitleList GetUserData(string gameId)
-        {
-            try
-            {
-                var task = Task.Run(() => GetUserDataAsync());
-                if (!task.Wait(15000))
-                {
-                    try { Logger.Warn($"GetUserData (sync) timed out"); } catch { }
-                    return null;
-                }
-                var userData = task.Result;
-                return userData?.TitlesList?.Find(x => x.Id == gameId);
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-        }
-
-        public bool EditIdExist(string userGameId)
-        {
-            try
-            {
-                var task = Task.Run(() => GetUserGamesList());
-                if (!task.Wait(15000))
-                {
-                    try { Logger.Warn($"EditIdExist({userGameId}) timed out"); } catch { }
-                    return false;
-                }
-                var ug = task.Result;
-                return ug?.Data?.GamesList?.Find(x => x.Id.ToString().IsEqual(userGameId))?.Id != null;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        #endregion
-
-
-        /// <summary>
-        /// Submits the current game data to the HowLongToBeat website.
-        /// </summary>
-        /// <param name="game">The Playnite game object.</param>
-        /// <param name="editData">The data to submit.</param>
-        /// <returns>True if submission is successful, otherwise false.</returns>
-        public async Task<bool> ApiSubmitData(Game game, EditData editData)
-        {
-            if (GetIsUserLoggedIn() && editData.UserId != 0 && editData.GameId != 0)
-            {
-                try
-                {
-                    List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-                    string payload = Serialization.ToJson(editData);
-                    List<KeyValuePair<string, string>> moreHeaders = new List<KeyValuePair<string, string>>
-                    {
-                        new KeyValuePair<string, string>("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")
-                    };
-                    string response = await PostJson(UrlPostData, payload, cookies);
-
-                    if (string.IsNullOrEmpty(response))
-                    {
-                        API.Instance.Notifications.Add(new NotificationMessage(
-                            $"{PluginDatabase.PluginName}-{game.Id}-Error",
-                            PluginDatabase.PluginName + Environment.NewLine + game.Name,
-                            NotificationType.Error
-                        ));
-                        Logger.Warn($"ApiSubmitData: empty response when posting data for game {game.Id}");
-                        return false;
-                    }
-
-                    try
-                    {
-                        var success = false;
-                        _ = Serialization.TryFromJson(response, out dynamic respObj);
-                        if (respObj != null)
-                        {
-                            try
-                            {
-                                if (respObj.error != null)
-                                {
-                                    string msg = string.Empty;
-                                    try { msg = respObj.error[0]?.ToString() ?? respObj.error.ToString(); } catch { msg = respObj.error.ToString(); }
-                                    API.Instance.Notifications.Add(new NotificationMessage(
-                                        $"{PluginDatabase.PluginName}-{game.Id}-Error",
-                                        PluginDatabase.PluginName + Environment.NewLine + game.Name + (msg.IsNullOrEmpty() ? string.Empty : Environment.NewLine + msg),
-                                        NotificationType.Error
-                                    ));
-                                    Logger.Warn($"ApiSubmitData error for game {game.Id}: {msg}");
-                                }
-                                else if (respObj.errors != null)
-                                {
-                                    string msg = respObj.errors.ToString();
-                                    API.Instance.Notifications.Add(new NotificationMessage(
-                                        $"{PluginDatabase.PluginName}-{game.Id}-Error",
-                                        PluginDatabase.PluginName + Environment.NewLine + game.Name + Environment.NewLine + msg,
-                                        NotificationType.Error
-                                    ));
-                                    Logger.Warn($"ApiSubmitData errors for game {game.Id}: {msg}");
-                                }
-                                else
-                                {
-                                    success = true;
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Common.LogError(ex, false, false, PluginDatabase.PluginName);
-                            }
-                        }
-                        else
-                        {
-                            Logger.Debug("ApiSubmitData: non-JSON response received; treating as success");
-                            success = true;
-                        }
-
-                        if (success)
-                        {
-                            PluginDatabase.RefreshUserData(editData.GameId.ToString());
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                        return false;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                    return false;
-                }
-            }
-            else
-            {
-                API.Instance.Notifications.Add(new NotificationMessage(
-                    $"{PluginDatabase.PluginName}-DataUpdate-Error",
-                    PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
-                    NotificationType.Error,
-                    () => PluginDatabase.Plugin.OpenSettingsView()
-                ));
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Updates the stored cookies for the current user session.
-        /// </summary>
-        public void UpdatedCookies()
-        {
-            try
-            {
-                // Run wait off the UI thread, then invoke UI work when ready
-                FireAndForget(Task.Run(async () =>
-                {
-                    var sw = System.Diagnostics.Stopwatch.StartNew();
-                    const int maxWaitMs = 60000; // 60s max wait for database load
-                    while (!PluginDatabase.IsLoaded)
-                    {
-                        await Task.Delay(100).ConfigureAwait(false);
-                        if (sw.ElapsedMilliseconds > maxWaitMs)
-                        {
-                            try { if (IsVerboseLoggingEnabled) Logger.Warn("Timeout waiting for PluginDatabase.IsLoaded in UpdatedCookies"); } catch { }
-                            break;
-                        }
-                    }
-
-                    try
-                    {
-                        await Application.Current.Dispatcher.InvokeAsync(() =>
-                        {
-                            try
-                            {
-                                if (PluginDatabase.Database.UserHltbData?.UserId != null && PluginDatabase.Database.UserHltbData.UserId != 0)
-                                {
-                                    Logger.Info($"Refresh HowLongToBeat user cookies");
-                                    List<HttpCookie> cookies = CookiesTools.GetNewWebCookies(new List<string> { UrlBase, UrlUser }, true);
-                                    _ = CookiesTools.SetStoredCookies(cookies);
-                                }
-                            }
-                            catch (Exception ex)
-                            {
-                                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                            }
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                    }
-                }), "UpdatedCookies");
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, true, PluginDatabase.PluginName);
-            }
-        }
-
-        /// <summary>
-        /// Try to extract script src URLs using HtmlAgilityPack via reflection. Returns null on failure.
-        /// Reflection is used because HAP is an optional dependency for the host application.
-        /// </summary>
-        private List<string> ExtractScriptUrlsWithHap(string html)
-        {
-            if (!HapAvailable || HapDocType == null || string.IsNullOrEmpty(html))
-            {
-                return null;
-            }
-
-            try
-            {
-                // Create HtmlDocument instance
-                dynamic doc = Activator.CreateInstance(HapDocType);
-                var loadHtml = HapDocType.GetMethod("LoadHtml");
-                loadHtml.Invoke(doc, new object[] { html });
-
-                var documentNode = HapDocType.GetProperty("DocumentNode").GetValue(doc);
-                var selectNodes = documentNode.GetType().GetMethod("SelectNodes", new Type[] { typeof(string) });
-                var nodes = selectNodes.Invoke(documentNode, new object[] { "//script[@src]" }) as System.Collections.IEnumerable;
-                if (nodes == null) return new List<string>();
-
-                var urls = new List<string>();
-                foreach (var node in nodes)
-                {
-                    try
-                    {
-                        var attrsProp = node.GetType().GetProperty("Attributes");
-                        if (attrsProp == null) continue;
-                        var attrs = attrsProp.GetValue(node);
-                        if (attrs == null) continue;
-                        var getAttr = attrs.GetType().GetMethod("Get", new Type[] { typeof(string) });
-                        if (getAttr == null) continue;
-                        var srcAttr = getAttr.Invoke(attrs, new object[] { "src" });
-                        if (srcAttr != null)
-                        {
-                            var valProp = srcAttr.GetType().GetProperty("Value");
-                            var val = valProp != null ? valProp.GetValue(srcAttr) as string : null;
-                            if (!string.IsNullOrEmpty(val)) urls.Add(val);
-                        }
-                    }
-                    catch { /* ignore per-node errors */ }
-                }
-
-                return urls;
-            }
-            catch (Exception ex)
-            {
-                try { Logger.Warn(ex, "HLTB: HtmlAgilityPack reflection extraction failed"); } catch { }
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Posts JSON payload to URL, optionally with cookies, and returns response string.
-        /// </summary>
-        private async Task<string> PostJson(string url, string payload, List<HttpCookie> cookies = null, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                HttpClientHandler handler = null;
-                if (cookies != null)
-                {
-                    try
-                    {
-                        var mi = typeof(CommonPluginsShared.Web).GetMethod("CreateCookiesContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-                        if (mi != null)
-                        {
-                            var container = mi.Invoke(null, new object[] { cookies }) as CookieContainer;
-                            handler = new HttpClientHandler { CookieContainer = container };
-                        }
-                    }
-                    catch { handler = new HttpClientHandler(); }
-                }
-
-                HttpClient client = null;
-                bool disposeClient = false;
-                try
-                {
-                    if (handler != null)
-                    {
-                        client = new HttpClient(handler)
-                        {
-                            Timeout = System.Threading.Timeout.InfiniteTimeSpan
-                        };
-                        disposeClient = true;
-                    }
-                    else
-                    {
-                        // Reuse the shared instance-level httpClient to avoid socket exhaustion
-                        client = httpClient ?? new HttpClient();
-                        disposeClient = false;
-                    }
-
-                    if (handler != null)
-                    {
-                        try { client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent); } catch { }
-                        try { client.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
-                    }
-
-                    var content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
-                    using (var resp = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false))
-                    {
-                        if (!resp.IsSuccessStatusCode)
-                        {
-                            try { Logger.Warn($"HTTP {(int)resp.StatusCode} posting to {url}"); } catch { }
-                            return string.Empty;
-                        }
-
-                        return await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    }
-                }
-                finally
-                {
-                    if (disposeClient && client != null)
-                    {
-                        try { client.Dispose(); } catch { }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, $"Error posting to {url}");
-                return string.Empty;
-            }
-        }
-
-        /// <summary>
-        /// Posts JSON payload using shared HttpClient and returns tuple (responseBody, statusCode, retryAfterHeader).
-        /// This is a local replacement for CommonPluginsShared.Web.PostJsonWithSharedClientWithStatus when the submodule isn't available.
-        /// </summary>
-        private async Task<(string body, int status, string retry)> PostJsonWithSharedClientWithStatus(string url, string payload, List<HttpHeader> headers = null, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                using (var request = new HttpRequestMessage(HttpMethod.Post, url))
-                {
-                    request.Content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
-
-                    if (headers != null)
-                    {
-                        foreach (var h in headers)
-                        {
-                            try
-                            {
-                                // Try to add to request headers; if invalid, try content headers
-                                if (!request.Headers.TryAddWithoutValidation(h.Key, h.Value))
-                                {
-                                    try { request.Content?.Headers.TryAddWithoutValidation(h.Key, h.Value); } catch { }
-                                }
-                            }
-                            catch { }
-                        }
-                    }
-
-                    using (var resp = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
-                    {
-                        int status = (int)resp.StatusCode;
-                        string retry = null;
-                        try
-                        {
-                            if (resp.Headers.TryGetValues("Retry-After", out var vals))
-                            {
-                                retry = vals.FirstOrDefault();
-                            }
-                        }
-                        catch { }
-
-                        string body = string.Empty;
-                        try { body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false); } catch { body = string.Empty; }
-
-                        if (!resp.IsSuccessStatusCode)
-                        {
-                            try { Logger.Warn($"HTTP {status} posting to {url}"); } catch { }
-                        }
-
-                        return (body, status, retry);
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex, false, $"Error posting to {url}");
-                return (string.Empty, 0, (string)null);
-            }
-        }
-        private static readonly Regex _scriptSrcRegex = new Regex("<script[^>]*src=[\\\"']([^\\\"']+)[\\\"'][^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-        private static Regex MyRegex() => _scriptSrcRegex;
-    }
+		private async Task<Dictionary<string, string>> GetAuthToken(string apiEndpoint)
+		{
+			try
+			{
+				// Double-checked locking: quick snapshot first to avoid locking in common case
+				var snapshotToken = CachedAuthToken;
+				var snapshotExpiry = CachedAuthTokenExpiry;
+				if (!string.IsNullOrEmpty(snapshotToken) && DateTime.UtcNow < snapshotExpiry)
+				{
+					//return snapshotToken;
+				}
+
+				// Re-check under lock to avoid race with a concurrent writer
+				lock (AuthTokenSync)
+				{
+					if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
+					{
+						//return CachedAuthToken;
+					}
+				}
+
+				List<HttpHeader> headers = new List<HttpHeader>
+				{
+					new HttpHeader { Key = "Referer", Value = UrlBase }
+				};
+				string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+				string response = null;
+				try
+				{
+					using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
+					using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+					{
+						try { request.Headers.Add("Referer", UrlBase); } catch { }
+
+						using (var resp = await httpClient.SendAsync(request, cts.Token).ConfigureAwait(false))
+						{
+							if (!resp.IsSuccessStatusCode)
+							{
+								try { Logger.Warn($"HTTP {(int)resp.StatusCode} downloading auth init {url}"); } catch { }
+								return null;
+							}
+
+							response = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+						}
+					}
+				}
+				catch (TaskCanceledException)
+				{
+					try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading auth init {url}"); } catch { }
+					return null;
+				}
+				catch (Exception ex)
+				{
+					Common.LogError(ex, false, true, PluginDatabase.PluginName);
+					return null;
+				}
+
+				var data = Serialization.FromJson<Dictionary<string, string>>(response);
+				if (data != null && data.TryGetValue("token", out string token))
+				{
+					lock (AuthTokenSync)
+					{
+						// Final re-check before writing to shared fields
+						if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
+						{
+							//return CachedAuthToken;
+						}
+						CachedAuthToken = token;
+						CachedAuthTokenExpiry = DateTime.UtcNow.AddSeconds(90);
+					}
+					if (data.TryGetValue("hpKey", out string hpKey) && data.TryGetValue("hpVal", out string hpVal))
+					{
+						var headerParts = new Dictionary<string, string>
+						{
+							{ "Token", token },
+							{ "Hpkey", hpKey },
+							{ "Hpval", hpVal }
+						};
+
+						return headerParts;
+					}
+
+
+					//return token;
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+			}
+			return null;
+		}
+
+
+		/// <summary>
+		/// Searches for games on HowLongToBeat by name and platform.
+		/// </summary>
+		/// <param name="name">Game name to search for.</param>
+		/// <param name="platform">Optional platform filter.</param>
+		/// <returns>Returns a list of <see cref="HltbDataUser"/> matching the search.</returns>
+		private async Task<List<HltbDataUser>> Search(string name, string platform = "")
+		{
+			try
+			{
+				SearchResult searchResult = await ApiSearch(name, platform);
+
+				List<HltbDataUser> search = searchResult?.Data?.Select(x =>
+					new HltbDataUser
+					{
+						Name = x.GameName,
+						Id = x.GameId.ToString(),
+						UrlImg = string.Format(UrlGameImg, x.GameImage),
+						Url = string.Format(UrlGame, x.GameId),
+						Platform = x.ProfilePlatform,
+						GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
+						GameHltbData = new HltbData
+						{
+							GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
+							MainStoryClassic = x.CompMain,
+							MainExtraClassic = x.CompPlus,
+							CompletionistClassic = x.Comp100,
+							SoloClassic = x.CompAll,
+							CoOpClassic = x.InvestedCo,
+							VsClassic = x.InvestedMp
+						},
+						NeedsDetails = !((x.CompMain > 0) || (x.CompAll > 0) || (x.CompPlus > 0) || (x.Comp100 > 0))
+					}
+				)?.ToList() ?? new List<HltbDataUser>();
+
+				if (search.Count != 0)
+				{
+					try
+					{
+						int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+						await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "Search");
+					}
+					catch { }
+
+					var tasks = search.Select(async x =>
+					{
+						bool acquiredGameSemaphore = false;
+						try
+						{
+							try
+							{
+								try
+								{
+									int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+									int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
+									int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
+									LogDebugVerbose($"Search: waiting semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
+								}
+								catch { }
+								var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
+								if (!acquired)
+								{
+									Logger.Warn($"Search: timeout waiting for game data semaphore for id={x.Id}");
+									return;
+								}
+								acquiredGameSemaphore = true;
+								try
+								{
+									int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+									int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
+									int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
+									LogDebugVerbose($"Search: acquired semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
+								}
+								catch { }
+							}
+							catch (Exception ex)
+							{
+								Common.LogError(ex, false, false, PluginDatabase.PluginName);
+							}
+							try
+							{
+								try
+								{
+									bool hasCoreTimes = (x.GameHltbData != null) && (
+										(x.GameHltbData.MainStoryClassic > 0) ||
+										(x.GameHltbData.MainStoryAverage > 0) ||
+										(x.GameHltbData.MainStoryMedian > 0)
+									);
+
+									if (hasCoreTimes)
+									{
+										LogDebugVerbose($"Search: skipping GetGameData for id={x.Id} (search result has times)");
+										x.NeedsDetails = false;
+									}
+									else
+									{
+										using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
+										{
+											try
+											{
+												x.GameHltbData = await GetGameData(x.Id, ctsGame.Token);
+												x.NeedsDetails = false;
+											}
+											catch (OperationCanceledException)
+											{
+												Logger.Warn($"Timeout {GameDataDownloadTimeoutMs}ms getting game data for {x.Id}");
+												x.GameHltbData = null;
+											}
+										}
+									}
+								}
+								catch (Exception ex)
+								{
+									Common.LogError(ex, false, false, PluginDatabase.PluginName);
+									x.GameHltbData = null;
+								}
+							}
+							finally
+							{
+								if (acquiredGameSemaphore)
+								{
+									try
+									{
+										DynamicSemaphore.Release();
+									}
+									catch { }
+								}
+								LogDebugVerbose($"Search: released semaphore for id={x.Id}");
+							}
+						}
+						catch (Exception ex)
+						{
+							Common.LogError(ex, false, false, PluginDatabase.PluginName);
+						}
+					}).ToArray();
+
+					await Task.WhenAll(tasks);
+					try
+					{
+						LogDebugVerbose($"Search summary: persistentCacheHits={PersistentCacheHits}, inMemoryHits={InMemoryCacheHits}, pageFetches={PageFetches}");
+					}
+					catch { }
+				}
+				return search;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				return new List<HltbDataUser>();
+			}
+		}
+
+		/// <summary>
+		/// Performs two search methods (normalized and original name) and merges results.
+		/// </summary>
+		/// <param name="name">Game name to search for.</param>
+		/// <param name="platform">Optional platform filter.</param>
+		/// <returns>Returns a list of <see cref="HltbSearch"/> with match percentages.</returns>
+		public async Task<List<HltbSearch>> SearchTwoMethod(string name, string platform = "", bool includeExtendedTimes = false)
+		{
+			// Apply manual aliases (exact normalized match) to support paired releases (e.g. Pokemon versions).
+			try
+			{
+				var settings = PluginDatabase?.PluginSettings?.Settings;
+				var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
+				var aliased = GameNameAliases.ApplyAlias(name, settings, userDataPath);
+				if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(name))
+				{
+					LogDebugVerbose($"HLTB aliases: '{SafeStr(name)}' -> '{SafeStr(aliased)}'");
+					name = aliased;
+				}
+			}
+			catch { }
+
+			string normalized = PlayniteTools.NormalizeGameName(name, true, true);
+
+			List<HltbDataUser> dataSearch = null;
+			List<HltbDataUser> dataSearchNormalized = null;
+
+			try
+			{
+				if (!string.IsNullOrEmpty(normalized) && !normalized.Equals(name, StringComparison.Ordinal))
+				{
+					var t1 = Search(name, platform);
+					var t2 = Search(normalized, platform);
+					await Task.WhenAll(t1, t2).ConfigureAwait(false);
+					dataSearch = t1.Result ?? new List<HltbDataUser>();
+					dataSearchNormalized = t2.Result ?? new List<HltbDataUser>();
+				}
+				else
+				{
+					dataSearch = await Search(name, platform);
+					dataSearchNormalized = new List<HltbDataUser>();
+				}
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+				dataSearch = dataSearch ?? new List<HltbDataUser>();
+				dataSearchNormalized = dataSearchNormalized ?? new List<HltbDataUser>();
+			}
+
+			var dataSearchFinal = new List<HltbDataUser>();
+			if (dataSearch != null) dataSearchFinal.AddRange(dataSearch);
+			if (dataSearchNormalized != null) dataSearchFinal.AddRange(dataSearchNormalized);
+
+			dataSearchFinal = dataSearchFinal.GroupBy(x => x.Id).Select(x => x.First()).ToList();
+
+			string searchNameLower = (name ?? string.Empty).ToLower();
+			var results = dataSearchFinal
+				.Where(x => x != null)
+				.Select(x => new HltbSearch
+				{
+					MatchPercent = Fuzz.Ratio(searchNameLower, (x.Name ?? string.Empty).ToLower()),
+					Data = x
+				})
+				.OrderByDescending(x => x.MatchPercent)
+				.ToList();
+
+			if (includeExtendedTimes)
+			{
+				try
+				{
+					const int maxDetails = 20;
+					var targets = results
+						.Select(r => r?.Data)
+						.Where(x => x != null && !string.IsNullOrEmpty(x.Id))
+						.Take(maxDetails)
+						.ToList();
+
+					if (targets.Count > 0)
+					{
+						try
+						{
+							int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+							await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "SearchTwoMethod+Details");
+						}
+						catch { }
+
+						var tasks = targets.Select(async x =>
+						{
+							bool acquiredGameSemaphore = false;
+							try
+							{
+								var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
+								if (!acquired)
+								{
+									return;
+								}
+								acquiredGameSemaphore = true;
+
+								using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
+								{
+									try
+									{
+										var details = await GetGameData(x.Id, ctsGame.Token);
+										if (details != null)
+										{
+											x.GameHltbData = details;
+											x.NeedsDetails = false;
+										}
+									}
+									catch (OperationCanceledException)
+									{
+										// Ignore timeout; keep basic search data
+									}
+									catch
+									{
+										// Ignore; keep basic search data
+									}
+								}
+							}
+							finally
+							{
+								if (acquiredGameSemaphore)
+								{
+									try { DynamicSemaphore.Release(); } catch { }
+								}
+							}
+						}).ToArray();
+
+						await Task.WhenAll(tasks).ConfigureAwait(false);
+					}
+				}
+				catch
+				{
+					// Best-effort enrichment; never fail the whole search.
+				}
+			}
+
+			return results;
+		}
+
+		/// <summary>
+		/// Performs an API search for games.
+		/// </summary>
+		/// <param name="name">Game name to search for.</param>
+		/// <param name="platform">Optional platform filter.</param>
+		/// <returns>Returns a <see cref="SearchResult"/> object.</returns>
+		private async Task<SearchResult> ApiSearch(string name, string platform = "")
+		{
+			try { EnsureMonitoringStarted(); } catch { }
+			int GetSearchTarget()
+			{
+				try
+				{
+					int baseTarget = MaxParallelSearches;
+					lock (BackoffSync)
+					{
+						if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
+						{
+							return Math.Min(baseTarget, SearchBackoffLimit);
+						}
+					}
+					return baseTarget;
+				}
+				catch
+				{
+					return SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
+				}
+			}
+
+			try
+			{
+				string cacheKey = (name ?? string.Empty) + "|" + (platform ?? string.Empty);
+				if (SearchCache.TryGetValue(cacheKey, out SearchResult cachedResult))
+				{
+					try { LogDebugVerbose($"ApiSearch cache hit for '{name}' platform='" + platform + "'"); } catch { }
+					return cachedResult;
+				}
+
+				List<HttpHeader> httpHeaders = new List<HttpHeader>
+				{
+					new HttpHeader { Key = "User-Agent", Value = Web.UserAgent },
+					new HttpHeader { Key = "Origin", Value = UrlBase },
+					new HttpHeader { Key = "Referer", Value = UrlBase }
+				};
+
+				SearchParam searchParam = new SearchParam
+				{
+					SearchTerms = name.Split(' ').ToList(),
+					SearchOptions = new SearchOptions { Games = new Games { Platform = platform } }
+				};
+
+				SearchResult searchResult = null;
+				string baseJson = Serialization.ToJson(searchParam);
+				var dict = Serialization.FromJson<Dictionary<string, object>>(baseJson);
+				string searchUrl = await GetSearchUrl();
+				bool tokenReused = !string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry;
+				Dictionary<string, string> headerParts = await GetAuthToken(searchUrl);
+				string token = headerParts["Token"];
+				string hpKey = headerParts["Hpkey"];
+				string hpVal = headerParts["Hpval"];
+				if (!token.IsNullOrEmpty())
+				{
+					httpHeaders.Add(new HttpHeader { Key = "x-auth-token", Value = token });
+				}
+
+				if (!hpKey.IsNullOrEmpty() && !hpVal.IsNullOrEmpty())
+				{
+					httpHeaders.Add(new HttpHeader { Key = "x-hp-key", Value = hpKey });
+					httpHeaders.Add(new HttpHeader { Key = "x-hp-val", Value = hpVal });
+					dict[hpKey] = hpVal;
+				}
+
+				string serializedBody = Serialization.ToJson(dict);
+
+				bool acquired = false;
+				try
+				{
+					try
+					{
+						try
+						{
+							int target = GetSearchTarget();
+							await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, target, SearchConcurrencySync, "ApiSearch+Initial");
+						}
+						catch { }
+
+						try
+						{
+							int targetLog = GetSearchTarget();
+							int availableLog = SearchSemaphore?.CurrentCount ?? 0;
+							int inFlightLog = Math.Max(0, targetLog - availableLog);
+							LogDebugVerbose($"ApiSearch: waiting search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
+						}
+						catch { }
+						bool waitOk = true;
+						if (SearchSemaphore != null)
+						{
+							waitOk = await SearchSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
+						}
+						if (!waitOk)
+						{
+							Logger.Warn($"ApiSearch: timeout waiting search semaphore for '{name}'");
+							return null;
+						}
+						acquired = true;
+						try
+						{
+							int targetLog = GetSearchTarget();
+							int availableLog = SearchSemaphore?.CurrentCount ?? 0;
+							int inFlightLog = Math.Max(0, targetLog - availableLog);
+							LogDebugVerbose($"ApiSearch: acquired search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
+						}
+						catch { }
+					}
+					catch (Exception ex)
+					{
+						Common.LogError(ex, false, false, PluginDatabase.PluginName);
+					}
+
+					var sw = Stopwatch.StartNew();
+					// Use local helper to avoid dependency on optional CommonPluginsShared submodule.
+					// Allow the POST to be cancelled/timeout independently of the shared HttpClient timeout by using a bounded CTS.
+					(string body, int status, string retry) postResult;
+					using (var postCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+					{
+						postResult = await PostJsonWithSharedClientWithStatus(UrlBase + searchUrl, serializedBody, httpHeaders, postCts.Token);
+					}
+					sw.Stop();
+					string json = postResult.body ?? string.Empty;
+					int statusCode = postResult.status;
+					string retryAfterHeader = postResult.retry;
+
+					try
+					{
+						if (statusCode == 429)
+						{
+							int backoffSeconds = 30;
+							if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsedSeconds))
+							{
+								backoffSeconds = Math.Max(1, parsedSeconds);
+							}
+
+							lock (BackoffSync)
+							{
+								int newLimit = Math.Max(1, CurrentSearchLimit / 2);
+								SearchBackoffLimit = newLimit;
+								SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
+							}
+
+							Logger.Warn($"ApiSearch: received 429 for '{name}'. Immediate backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
+						}
+					}
+					catch { }
+
+					try
+					{
+						try
+						{
+							RecentSearchSamples.Enqueue(sw.ElapsedMilliseconds);
+							while (RecentSearchSamples.Count > RecentSamplesWindow)
+							{
+								RecentSearchSamples.TryDequeue(out _);
+							}
+						}
+						catch { }
+
+						try
+						{
+							RecentSearchStatusCodes.Enqueue(statusCode);
+							while (RecentSearchStatusCodes.Count > RecentStatusWindow)
+							{
+								RecentSearchStatusCodes.TryDequeue(out _);
+							}
+						}
+						catch { }
+
+						LogDebugVerbose($"ApiSearch elapsed={sw.ElapsedMilliseconds}ms tokenReused={tokenReused} status={statusCode}");
+					}
+					catch { }
+
+					_ = Serialization.TryFromJson(json, out searchResult);
+
+					try
+					{
+						bool successSample = searchResult != null && searchResult.Data != null && statusCode != 429;
+						SearchConcurrencyController?.ReportSample(sw.ElapsedMilliseconds, successSample);
+					}
+					catch { }
+
+					int postLockPendingConsume = 0;
+					try
+					{
+						var codes = RecentSearchStatusCodes.ToArray();
+						if (codes.Length > 0)
+						{
+							int count429 = codes.Count(c => c == 429);
+							double frac = count429 / (double)codes.Length;
+							if (count429 >= 3 && frac >= 0.05)
+							{
+								lock (BackoffSync)
+								{
+									if (SearchBackoffLimit == 0 || DateTime.UtcNow >= SearchBackoffUntil)
+									{
+										int newLimit = Math.Max(1, CurrentSearchLimit / 2);
+										SearchBackoffLimit = newLimit;
+
+										int backoffSeconds = 30;
+										try
+										{
+											if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsed))
+											{
+												backoffSeconds = Math.Max(1, parsed);
+											}
+										}
+										catch { }
+										SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
+										Logger.Warn($"ApiSearch: detected elevated 429 rate ({count429}/{codes.Length}). Applying temporary search backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
+										try
+										{
+											int currentLimitSnapshot;
+											lock (SearchConcurrencySync)
+											{
+												currentLimitSnapshot = CurrentSearchLimit;
+											}
+											int diff = SearchBackoffLimit - currentLimitSnapshot;
+											if (diff > 0)
+											{
+												try { SearchSemaphore.Release(diff); } catch { }
+												lock (SearchConcurrencySync)
+												{
+													CurrentSearchLimit = SearchBackoffLimit;
+												}
+											}
+											else if (diff < 0)
+											{
+												postLockPendingConsume = -diff;
+											}
+										}
+										catch { }
+									}
+								}
+							}
+						}
+					}
+					catch { }
+
+					try
+					{
+						if (postLockPendingConsume > 0)
+						{
+							int backoffSnapshot;
+							lock (BackoffSync)
+							{
+								backoffSnapshot = SearchBackoffLimit;
+							}
+
+							await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, backoffSnapshot, SearchConcurrencySync, "ApiSearch+PostBackoff");
+						}
+					}
+					catch { }
+
+					try
+					{
+						if (searchResult != null)
+						{
+							SearchCache.TryAdd(cacheKey, searchResult);
+						}
+					}
+					catch { }
+
+					return searchResult;
+				}
+				finally
+				{
+					if (acquired)
+					{
+						try
+						{
+							SearchSemaphore.Release();
+							LogDebugVerbose($"ApiSearch: released search semaphore for '{name}'");
+						}
+						catch { }
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Opens a selection window for the user to choose the correct game data.
+		/// </summary>
+		/// <param name="game">The Playnite game object.</param>
+		/// <param name="data">Optional list of search results.</param>
+		/// <returns>Returns a <see cref="GameHowLongToBeat"/> object if a selection is made, otherwise null.</returns>
+		public GameHowLongToBeat SearchData(Game game, List<HltbDataUser> data = null)
+		{
+			Common.LogDebug(true, $"Search data for {game.Name}");
+			if (API.Instance.ApplicationInfo.Mode == ApplicationMode.Desktop)
+			{
+				HowLongToBeatSelect ViewExtension = null;
+				_ = Application.Current.Dispatcher.BeginInvoke((Action)delegate
+				{
+					ViewExtension = new HowLongToBeatSelect(game, data);
+					Window windowExtension = PlayniteUiHelper.CreateExtensionWindow(ResourceProvider.GetString("LOCSelection") + " - " + game.Name + " - " + (game.Source?.Name ?? "Playnite"), ViewExtension);
+					_ = windowExtension.ShowDialog();
+				}).Wait();
+
+				if (ViewExtension.GameHowLongToBeat?.Items.Count > 0)
+				{
+					return ViewExtension.GameHowLongToBeat;
+				}
+			}
+			return null;
+		}
+
+		public HltbDataUser SearchDataAuto(string gameName, string platform = "")
+		{
+			string traceId = null;
+			try
+			{
+				if (string.IsNullOrEmpty(gameName))
+				{
+					return null;
+				}
+
+				// Apply manual aliases (exact normalized match) early so all subsequent matching uses the aliased title.
+				try
+				{
+					var settings = PluginDatabase?.PluginSettings?.Settings;
+					var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
+					var aliased = GameNameAliases.ApplyAlias(gameName, settings, userDataPath);
+					if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(gameName))
+					{
+						LogDebugVerbose($"HLTB aliases: '{SafeStr(gameName)}' -> '{SafeStr(aliased)}'");
+						gameName = aliased;
+					}
+				}
+				catch { }
+
+				traceId = Guid.NewGuid().ToString("N").Substring(0, 8);
+
+				var hltbSettings = PluginDatabase?.PluginSettings?.Settings;
+
+				if (IsVerboseLoggingEnabled)
+				{
+					try
+					{
+						Logger.Debug($"SearchDataAuto[{traceId}]: start name='{SafeStr(gameName)}' platform='{SafeStr(platform)}' UseMatchValue={hltbSettings?.UseMatchValue} MatchValue={hltbSettings?.MatchValue}");
+					}
+					catch { }
+				}
+
+				List<HltbSearch> results = null;
+				bool gotResults = false;
+				try
+				{
+					// 1) First pass: fast search (no details fetch)
+					gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 15000, Logger);
+					if (!gotResults)
+					{
+						if (IsVerboseLoggingEnabled)
+						{
+							try { Logger.Warn($"SearchDataAuto[{traceId}]: SearchTwoMethod timed out after 15000ms; retrying once"); } catch { }
+						}
+
+						gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 30000, Logger);
+					}
+				}
+				catch (Exception ex)
+				{
+					if (IsVerboseLoggingEnabled)
+					{
+						try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
+					}
+					results = null;
+				}
+
+				if (!gotResults)
+				{
+					if (IsVerboseLoggingEnabled)
+					{
+						try { Logger.Debug($"SearchDataAuto[{traceId}]: no results (timeout)"); } catch { }
+					}
+					return null;
+				}
+
+				if (results == null || results.Count == 0)
+				{
+					if (IsVerboseLoggingEnabled)
+					{
+						try { Logger.Debug($"SearchDataAuto[{traceId}]: no results"); } catch { }
+					}
+					return null;
+				}
+
+				if (IsVerboseLoggingEnabled)
+				{
+					try
+					{
+						Logger.Debug($"SearchDataAuto[{traceId}]: results count={results.Count}");
+						int take = Math.Min(8, results.Count);
+						for (int i = 0; i < take; i++)
+						{
+							var r = results[i];
+							var d = r?.Data;
+							long ttb = 0;
+							bool hasAnyTime = false;
+							try
+							{
+								ttb = d?.GameHltbData?.TimeToBeat ?? 0;
+								hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
+							}
+							catch { }
+
+							Logger.Debug($"SearchDataAuto[{traceId}]: candidate[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
+						}
+					}
+					catch { }
+				}
+
+				try
+				{
+					var nQuery = PlayniteTools.NormalizeGameName(gameName ?? string.Empty, true, true);
+					if (!string.IsNullOrEmpty(nQuery))
+					{
+						var exact = results
+							.Where(r => r?.Data != null)
+							.Select(r => new { r.MatchPercent, Data = r.Data, Norm = PlayniteTools.NormalizeGameName(r.Data?.Name ?? string.Empty, true, true) })
+							.Where(x => !string.IsNullOrEmpty(x.Norm) && x.Norm.IsEqual(nQuery))
+							.OrderByDescending(x => x.MatchPercent)
+							.FirstOrDefault();
+
+						if (exact?.Data != null)
+						{
+							if (hltbSettings != null && hltbSettings.UseMatchValue && exact.MatchPercent < hltbSettings.MatchValue && exact.MatchPercent < 98)
+							{
+								if (IsVerboseLoggingEnabled)
+								{
+									try { Logger.Debug($"SearchDataAuto[{traceId}]: exact normalized match rejected by MatchValue score={exact.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+								}
+								return null;
+							}
+
+							if (IsVerboseLoggingEnabled)
+							{
+								try { Logger.Debug($"SearchDataAuto[{traceId}]: selected exact normalized match id={SafeStr(exact.Data?.Id)} title='{SafeStr(exact.Data?.Name)}' score={exact.MatchPercent}"); } catch { }
+							}
+
+							return exact.Data;
+						}
+					}
+				}
+				catch { }
+
+				var best = results[0];
+				if (best?.Data == null)
+				{
+					if (IsVerboseLoggingEnabled)
+					{
+						try { Logger.Debug($"SearchDataAuto[{traceId}]: best result had null data"); } catch { }
+					}
+					return null;
+				}
+
+				try
+				{
+					if (hltbSettings != null && hltbSettings.UseMatchValue && best.MatchPercent < hltbSettings.MatchValue)
+					{
+						if (best.MatchPercent >= 98)
+						{
+							if (IsVerboseLoggingEnabled)
+							{
+								try { Logger.Debug($"SearchDataAuto[{traceId}]: best below MatchValue but accepted via near-perfect safety net score={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+							}
+							return best.Data;
+						}
+
+						if (IsVerboseLoggingEnabled)
+						{
+							try { Logger.Debug($"SearchDataAuto[{traceId}]: rejected by MatchValue bestScore={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+						}
+						return null;
+					}
+				}
+				catch { }
+
+				// 2) Ambiguity handling: if multiple top results are close in score,
+				// fetch details for top candidates and prefer one that actually has times.
+				try
+				{
+					if (results.Count > 1)
+					{
+						var second = results[1];
+						bool ambiguous = false;
+						try
+						{
+							ambiguous = (best.MatchPercent < 100 && second != null && (best.MatchPercent - second.MatchPercent) <= 3);
+						}
+						catch { }
+
+						if (IsVerboseLoggingEnabled)
+						{
+							try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguity check best={best.MatchPercent} second={second?.MatchPercent} ambiguous={ambiguous}"); } catch { }
+						}
+
+						if (ambiguous)
+						{
+							List<HltbSearch> enriched = null;
+							try
+							{
+								enriched = TaskHelpers.RunSyncWithTimeout(() => SearchTwoMethod(gameName, platform, includeExtendedTimes: true), 20000);
+							}
+							catch (Exception ex)
+							{
+								if (IsVerboseLoggingEnabled)
+								{
+									try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: enrichment SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
+								}
+								enriched = null;
+							}
+
+							if (enriched != null && enriched.Count > 0)
+							{
+								if (IsVerboseLoggingEnabled)
+								{
+									try
+									{
+										Logger.Debug($"SearchDataAuto[{traceId}]: enriched count={enriched.Count}");
+										int take = Math.Min(8, enriched.Count);
+										for (int i = 0; i < take; i++)
+										{
+											var r = enriched[i];
+											var d = r?.Data;
+											long ttb = 0;
+											bool hasAnyTime = false;
+											try
+											{
+												ttb = d?.GameHltbData?.TimeToBeat ?? 0;
+												hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
+											}
+											catch { }
+
+											Logger.Debug($"SearchDataAuto[{traceId}]: enriched[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
+										}
+									}
+									catch { }
+								}
+
+								var withTimes = enriched
+									.Where(r => r?.Data?.GameHltbData != null)
+									.Where(r =>
+									{
+										try
+										{
+											return r.Data.GameHltbData.TimeToBeat > 0 || r.Data.GameHltbData.MainStoryClassic > 0 || r.Data.GameHltbData.MainExtraClassic > 0 || r.Data.GameHltbData.CompletionistClassic > 0 || r.Data.GameHltbData.SoloClassic > 0;
+										}
+										catch { return false; }
+									})
+									.OrderByDescending(r => r.MatchPercent)
+									.FirstOrDefault();
+
+								if (withTimes?.Data != null)
+								{
+									if (hltbSettings != null && hltbSettings.UseMatchValue && withTimes.MatchPercent < hltbSettings.MatchValue && withTimes.MatchPercent < 98)
+									{
+										if (IsVerboseLoggingEnabled)
+										{
+											try { Logger.Debug($"SearchDataAuto[{traceId}]: enriched withTimes rejected by MatchValue score={withTimes.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+										}
+										return null;
+									}
+
+									if (IsVerboseLoggingEnabled)
+									{
+										try { Logger.Debug($"SearchDataAuto[{traceId}]: selected enriched withTimes id={SafeStr(withTimes.Data?.Id)} title='{SafeStr(withTimes.Data?.Name)}' score={withTimes.MatchPercent}"); } catch { }
+									}
+									return withTimes.Data;
+								}
+
+								var bestEnriched = enriched[0];
+								if (bestEnriched?.Data != null)
+								{
+									if (hltbSettings != null && hltbSettings.UseMatchValue && bestEnriched.MatchPercent < hltbSettings.MatchValue && bestEnriched.MatchPercent < 98)
+									{
+										if (IsVerboseLoggingEnabled)
+										{
+											try { Logger.Debug($"SearchDataAuto[{traceId}]: bestEnriched rejected by MatchValue score={bestEnriched.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+										}
+										return null;
+									}
+
+									if (IsVerboseLoggingEnabled)
+									{
+										try { Logger.Debug($"SearchDataAuto[{traceId}]: selected bestEnriched id={SafeStr(bestEnriched.Data?.Id)} title='{SafeStr(bestEnriched.Data?.Name)}' score={bestEnriched.MatchPercent}"); } catch { }
+									}
+									return bestEnriched.Data;
+								}
+							}
+
+							if (best.MatchPercent >= 98)
+							{
+								if (IsVerboseLoggingEnabled)
+								{
+									try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguous but fell back to near-perfect best score={best.MatchPercent} id={SafeStr(best.Data?.Id)}"); } catch { }
+								}
+								return best.Data;
+							}
+						}
+					}
+				}
+				catch { }
+
+				if (IsVerboseLoggingEnabled)
+				{
+					try { Logger.Debug($"SearchDataAuto[{traceId}]: selected best (default) id={SafeStr(best.Data?.Id)} title='{SafeStr(best.Data?.Name)}' score={best.MatchPercent}"); } catch { }
+				}
+
+				return best.Data;
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, true, PluginDatabase?.PluginName); } catch { }
+				return null;
+			}
+		}
+
+		#endregion
+
+		#region user account
+
+		/// <summary>
+		/// Checks if the user is currently logged in to HowLongToBeat (async).
+		/// </summary>
+		/// <returns>True if logged in, otherwise false.</returns>
+		public async Task<bool> GetIsUserLoggedInAsync()
+		{
+			// Avoid getting stuck in a "logged out" state if this method is called before PluginDatabase is loaded.
+			// Use stored cookies directly to check the current session.
+			try
+			{
+				var now = DateTime.UtcNow;
+				if (lastLoginCheckResult != null)
+				{
+					var ttl = lastLoginCheckResult == true ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(1);
+					if (now - lastLoginCheckUtc < ttl)
+					{
+						return lastLoginCheckResult.Value;
+					}
+				}
+
+				int userId = await GetUserId().ConfigureAwait(false);
+				UserId = userId;
+				IsConnected = userId != 0;
+
+				lastLoginCheckUtc = now;
+				lastLoginCheckResult = userId != 0;
+
+				if (IsVerboseLoggingEnabled)
+				{
+					Logger.Debug($"HLTB Auth: GetIsUserLoggedInAsync userId={userId} IsConnected={IsConnected}");
+				}
+
+				return userId != 0;
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+				UserId = 0;
+				IsConnected = false;
+				lastLoginCheckUtc = DateTime.UtcNow;
+				lastLoginCheckResult = false;
+				return false;
+			}
+		}
+
+		public bool GetIsUserLoggedIn()
+		{
+			try
+			{
+				return Task.Run(() => GetIsUserLoggedInAsync()).Result;
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Initiates the login process for HowLongToBeat.
+		/// </summary>
+		public void Login()
+		{
+			// Use a DispatcherOperation so we can attach the Completed handler cleanly
+			System.Windows.Threading.DispatcherOperation op = null;
+
+			try
+			{
+				op = Application.Current.Dispatcher.BeginInvoke((Action)delegate
+				{
+					Logger.Info("Login()");
+
+					bool cookiesCaptured = false;
+
+					WebViewSettings settings = new WebViewSettings
+					{
+						JavaScriptEnabled = true,
+						WindowHeight = 670,
+						WindowWidth = 490,
+						UserAgent = Web.UserAgent
+					};
+
+					using (IWebView webView = API.Instance.WebViews.CreateView(settings))
+					{
+						webView.LoadingChanged += (s, e) =>
+						{
+							try
+							{
+								Common.LogDebug(true, $"NavigationChanged - {webView.GetCurrentAddress()}");
+
+								if (!cookiesCaptured && webView.GetCurrentAddress().StartsWith(UrlBase + "/user/"))
+								{
+									cookiesCaptured = true;
+									UserLogin = WebUtility.HtmlDecode(webView.GetCurrentAddress().Replace(UrlBase + "/user/", string.Empty));
+									IsConnected = true;
+
+									// Give the embedded WebView a moment to commit cookies.
+									FireAndForget(Task.Run(async () =>
+									{
+										try
+										{
+											await Task.Delay(1000).ConfigureAwait(false);
+										}
+										catch { }
+
+										try
+										{
+											await Application.Current.Dispatcher.InvokeAsync(() =>
+											{
+												try
+												{
+													List<HttpCookie> cookies = CookiesTools.GetWebCookies(deleteCookies: false, webView: webView);
+													bool saved = CookiesTools.SetStoredCookies(cookies);
+													Logger.Info($"HLTB Auth: captured cookies from login webview count={cookies?.Count ?? 0} saved={saved}");
+													LogCookieSummary("login captured", cookies);
+
+													// Invalidate cached login check so next calls re-check if needed.
+													lastLoginCheckResult = null;
+													lastLoginCheckUtc = DateTime.MinValue;
+												}
+												catch (Exception ex)
+												{
+													Common.LogError(ex, false, true, PluginDatabase.PluginName);
+												}
+												finally
+												{
+													try { webView.Close(); } catch { }
+												}
+											});
+										}
+										catch (Exception ex)
+										{
+											try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+											try
+											{
+												var closeOp = Application.Current.Dispatcher.BeginInvoke((Action)(() => { try { webView.Close(); } catch { } }));
+												try { FireAndForget(closeOp?.Task, "login close webview (BeginInvoke)"); } catch { }
+											}
+											catch { }
+										}
+									}), "login captured");
+
+									// (task is fire-and-forget intentionally)
+
+									return;
+								}
+							}
+							catch { }
+						};
+
+						IsConnected = false;
+						webView.Navigate(UrlLogOut);
+						_ = webView.OpenDialog();
+					}
+				});
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+			}
+
+			try
+			{
+				if (op != null)
+				{
+					op.Completed += (s, e) =>
+					{
+						try
+						{
+							if ((bool)IsConnected)
+							{
+								_ = Application.Current.Dispatcher?.BeginInvoke((Action)delegate
+								{
+									try
+									{
+										PluginDatabase.PluginSettings.Settings.UserLogin = UserLogin;
+
+										PluginDatabase.Plugin.SavePluginSettings(PluginDatabase.PluginSettings.Settings);
+
+										FireAndForget(Task.Run(async () =>
+										{
+											try { UserId = await GetUserId().ConfigureAwait(false); } catch { }
+											try { PluginDatabase.RefreshUserData(); } catch { }
+										}), "post-login refresh");
+									}
+									catch (Exception ex)
+									{
+										Common.LogError(ex, false, true, PluginDatabase.PluginName);
+									}
+								});
+							}
+						}
+						catch { }
+					};
+				}
+			}
+			catch { }
+		}
+
+		/// <summary>
+		/// Retrieves the user ID of the currently logged-in user.
+		/// </summary>
+		/// <returns>User ID as integer, or 0 if not logged in.</returns>
+		private async Task<int> GetUserId()
+		{
+			try
+			{
+				List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+				LogCookieSummary("GetUserId stored", cookies);
+
+				if (cookies == null || cookies.Count == 0)
+				{
+					try { Logger.Info("HLTB Auth: no stored cookies available"); } catch { }
+				}
+				string response = await Web.DownloadPageText(UrlUser, cookies);
+				dynamic t = Serialization.FromJson<dynamic>(response);
+
+				int userId = response == "{}" ? 0 : t?.data[0]?.user_id ?? 0;
+				if (IsVerboseLoggingEnabled)
+				{
+					Logger.Debug($"HLTB Auth: GetUserId responseLen={response?.Length ?? 0} userId={userId}");
+				}
+
+				return userId;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false);
+				return 0;
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the list of games for the current user.
+		/// </summary>
+		/// <returns>Returns a <see cref="UserGamesList"/> object.</returns>
+		private async Task<UserGamesList> GetUserGamesList()
+		{
+			try
+			{
+				List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+
+				UserGamesListParam userGamesListParam = new UserGamesListParam { UserId = UserId };
+				string payload = Serialization.ToJson(userGamesListParam);
+
+				string json = await PostJson(string.Format(UrlUserGamesList, UserId), payload, cookies);
+				_ = Serialization.TryFromJson(json, out UserGamesList userGamesList);
+
+				return userGamesList;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Converts a <see cref="GamesList"/> entry to a <see cref="TitleList"/>.
+		/// </summary>
+		/// <param name="gamesList">The games list entry.</param>
+		/// <returns>Returns a <see cref="TitleList"/> object.</returns>
+		private TitleList GetTitleList(GamesList gamesList)
+		{
+			try
+			{
+				_ = DateTime.TryParse(gamesList.DateUpdated, out DateTime lastUpdate);
+				_ = DateTime.TryParse(gamesList.DateComplete, out DateTime completion);
+				_ = DateTime.TryParse(gamesList.DateStart, out DateTime dateStart);
+				DateTime? completionFinal = null;
+				if (completion != default)
+				{
+					completionFinal = completion;
+				}
+
+				TitleList titleList = new TitleList
+				{
+					UserGameId = gamesList.Id.ToString(),
+					GameName = gamesList.CustomTitle,
+					Platform = gamesList.Platform,
+					Id = gamesList.GameId.ToString(),
+					CurrentTime = gamesList.InvestedPro,
+					IsReplay = gamesList.PlayCount == 2,
+					IsRetired = gamesList.ListRetired == 1,
+					Storefront = gamesList.PlayStorefront,
+					StartDate = dateStart,
+					LastUpdate = lastUpdate,
+					Completion = completionFinal,
+					HltbUserData = new HltbData
+					{
+						GameType = gamesList.GameType.IsEqual("game") ? GameType.Game : gamesList.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
+						MainStoryClassic = gamesList.CompMain,
+						MainExtraClassic = gamesList.CompPlus,
+						CompletionistClassic = gamesList.Comp100,
+						SoloClassic = 0,
+						CoOpClassic = gamesList.InvestedCo,
+						VsClassic = gamesList.InvestedMp
+					},
+					GameStatuses = new List<GameStatus>()
+				};
+
+				if (gamesList.ListBacklog == 1)
+				{
+					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Backlog });
+				}
+
+				if (gamesList.ListComp == 1)
+				{
+					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Completed });
+				}
+
+				if (gamesList.ListCustom == 1)
+				{
+					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.CustomTab });
+				}
+
+				if (gamesList.ListPlaying == 1)
+				{
+					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Playing });
+				}
+
+				if (gamesList.ListReplay == 1)
+				{
+					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Replays });
+				}
+
+				if (gamesList.ListRetired == 1)
+				{
+					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Retired });
+				}
+
+				return titleList;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the edit data for a specific user game entry.
+		/// </summary>
+		/// <param name="gameName">The name of the game.</param>
+		/// <param name="userGameId">The user game ID.</param>
+		/// <returns>Returns an <see cref="EditData"/> object.</returns>
+		public async Task<EditData> GetEditData(string gameName, string userGameId)
+		{
+			Logger.Info($"GetEditData({gameName}, {userGameId})");
+			try
+			{
+				List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+
+				string response = await Web.DownloadStringData(string.Format(UrlPostDataEdit, userGameId), cookies);
+				if (string.IsNullOrEmpty(response) || !response.Contains("__NEXT_DATA__"))
+				{
+					Logger.Warn($"No EditData for {gameName} - {userGameId}");
+					return null;
+				}
+
+				string jsonData = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
+				_ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
+				if (parseEx != null)
+				{
+					Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
+				}
+
+				return next_data?.Props?.PageProps?.EditData?.UserId != null
+					? next_data.Props.PageProps.EditData
+					: throw new Exception($"No EditData find for {gameName} - {userGameId}");
+			}
+			catch (Exception ex)
+			{
+				if (IsFirst)
+				{
+					IsFirst = false;
+					return await GetEditData(gameName, userGameId);
+				}
+				else
+				{
+					Common.LogError(ex, false, true, PluginDatabase.PluginName);
+					return null;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Loads user stats from the local file.
+		/// </summary>
+		/// <returns>Returns a <see cref="HltbUserStats"/> object.</returns>
+		public HltbUserStats LoadUserData()
+		{
+			string pathHltbUserStats = Path.Combine(PluginDatabase.Plugin.GetPluginUserDataPath(), "HltbUserStats.json");
+			HltbUserStats hltbDataUser = new HltbUserStats();
+
+			if (File.Exists(pathHltbUserStats))
+			{
+				try
+				{
+					if (!Serialization.TryFromJsonFile(pathHltbUserStats, out hltbDataUser))
+					{
+						return new HltbUserStats();
+					}
+					hltbDataUser.TitlesList = hltbDataUser.TitlesList.Where(x => x != null).ToList();
+				}
+				catch (Exception ex)
+				{
+					Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				}
+			}
+
+			return hltbDataUser;
+		}
+
+		/// <summary>
+		/// Retrieves the user data from HowLongToBeat (async).
+		/// </summary>
+		/// <returns>Returns a <see cref="HltbUserStats"/> object, or null if not logged in.</returns>
+		public async Task<HltbUserStats> GetUserDataAsync()
+		{
+			if (await GetIsUserLoggedInAsync().ConfigureAwait(false))
+			{
+				HltbUserStats hltbUserStats = new HltbUserStats
+				{
+					Login = UserLogin.IsNullOrEmpty() ? PluginDatabase.Database.UserHltbData.Login : UserLogin,
+					UserId = (UserId == 0) ? PluginDatabase.Database.UserHltbData.UserId : UserId,
+					TitlesList = new List<TitleList>()
+				};
+
+				UserGamesList userGamesList = null;
+				try { userGamesList = await GetUserGamesList().ConfigureAwait(false); } catch { userGamesList = null; }
+				if (userGamesList == null)
+				{
+					return null;
+				}
+
+				try
+				{
+					userGamesList.Data.GamesList.ForEach(x =>
+					{
+						TitleList titleList = GetTitleList(x);
+						hltbUserStats.TitlesList.Add(titleList);
+					});
+				}
+				catch (Exception ex)
+				{
+					Common.LogError(ex, false, true, PluginDatabase.PluginName);
+					return null;
+				}
+
+				return hltbUserStats;
+			}
+			else
+			{
+				API.Instance.Notifications.Add(new NotificationMessage(
+					$"{PluginDatabase.PluginName}-Import-Error",
+					PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
+					NotificationType.Error,
+					() => PluginDatabase.Plugin.OpenSettingsView()
+				));
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Synchronous wrapper for backwards compatibility; runs async method on thread-pool.
+		/// </summary>
+		public HltbUserStats GetUserData()
+		{
+			try
+			{
+				var task = Task.Run(() => GetUserDataAsync());
+				if (!task.Wait(15000))
+				{
+					try { Logger.Warn("GetUserData timed out"); } catch { }
+					return null;
+				}
+				return task.Result;
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Finds the existing user game ID for a given game ID (async).
+		/// </summary>
+		public async Task<string> FindIdExistingAsync(string gameId)
+		{
+			try
+			{
+				var ug = await GetUserGamesList().ConfigureAwait(false);
+				return ug?.Data?.GamesList?.Find(x => x.GameId.ToString().IsEqual(gameId))?.Id.ToString() ?? null;
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Synchronous wrapper for backwards compatibility.
+		/// </summary>
+		public string FindIdExisting(string gameId)
+		{
+			try
+			{
+				var task = Task.Run(() => FindIdExistingAsync(gameId));
+				if (!task.Wait(15000))
+				{
+					try { Logger.Warn($"FindIdExisting({gameId}) timed out"); } catch { }
+					return null;
+				}
+				return task.Result;
+			}
+			catch (Exception ex)
+			{
+				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Synchronous helper: get TitleList for a specific game id from user data.
+		/// </summary>
+		public TitleList GetUserData(string gameId)
+		{
+			try
+			{
+				var task = Task.Run(() => GetUserDataAsync());
+				if (!task.Wait(15000))
+				{
+					try { Logger.Warn($"GetUserData (sync) timed out"); } catch { }
+					return null;
+				}
+				var userData = task.Result;
+				return userData?.TitlesList?.Find(x => x.Id == gameId);
+			}
+			catch (Exception)
+			{
+				return null;
+			}
+		}
+
+		public bool EditIdExist(string userGameId)
+		{
+			try
+			{
+				var task = Task.Run(() => GetUserGamesList());
+				if (!task.Wait(15000))
+				{
+					try { Logger.Warn($"EditIdExist({userGameId}) timed out"); } catch { }
+					return false;
+				}
+				var ug = task.Result;
+				return ug?.Data?.GamesList?.Find(x => x.Id.ToString().IsEqual(userGameId))?.Id != null;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
+		#endregion
+
+
+		/// <summary>
+		/// Submits the current game data to the HowLongToBeat website.
+		/// </summary>
+		/// <param name="game">The Playnite game object.</param>
+		/// <param name="editData">The data to submit.</param>
+		/// <returns>True if submission is successful, otherwise false.</returns>
+		public async Task<bool> ApiSubmitData(Game game, EditData editData)
+		{
+			if (GetIsUserLoggedIn() && editData.UserId != 0 && editData.GameId != 0)
+			{
+				try
+				{
+					List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+					string payload = Serialization.ToJson(editData);
+					List<KeyValuePair<string, string>> moreHeaders = new List<KeyValuePair<string, string>>
+					{
+						new KeyValuePair<string, string>("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")
+					};
+					string response = await PostJson(UrlPostData, payload, cookies);
+
+					if (string.IsNullOrEmpty(response))
+					{
+						API.Instance.Notifications.Add(new NotificationMessage(
+							$"{PluginDatabase.PluginName}-{game.Id}-Error",
+							PluginDatabase.PluginName + Environment.NewLine + game.Name,
+							NotificationType.Error
+						));
+						Logger.Warn($"ApiSubmitData: empty response when posting data for game {game.Id}");
+						return false;
+					}
+
+					try
+					{
+						var success = false;
+						_ = Serialization.TryFromJson(response, out dynamic respObj);
+						if (respObj != null)
+						{
+							try
+							{
+								if (respObj.error != null)
+								{
+									string msg = string.Empty;
+									try { msg = respObj.error[0]?.ToString() ?? respObj.error.ToString(); } catch { msg = respObj.error.ToString(); }
+									API.Instance.Notifications.Add(new NotificationMessage(
+										$"{PluginDatabase.PluginName}-{game.Id}-Error",
+										PluginDatabase.PluginName + Environment.NewLine + game.Name + (msg.IsNullOrEmpty() ? string.Empty : Environment.NewLine + msg),
+										NotificationType.Error
+									));
+									Logger.Warn($"ApiSubmitData error for game {game.Id}: {msg}");
+								}
+								else if (respObj.errors != null)
+								{
+									string msg = respObj.errors.ToString();
+									API.Instance.Notifications.Add(new NotificationMessage(
+										$"{PluginDatabase.PluginName}-{game.Id}-Error",
+										PluginDatabase.PluginName + Environment.NewLine + game.Name + Environment.NewLine + msg,
+										NotificationType.Error
+									));
+									Logger.Warn($"ApiSubmitData errors for game {game.Id}: {msg}");
+								}
+								else
+								{
+									success = true;
+								}
+							}
+							catch (Exception ex)
+							{
+								Common.LogError(ex, false, false, PluginDatabase.PluginName);
+							}
+						}
+						else
+						{
+							Logger.Debug("ApiSubmitData: non-JSON response received; treating as success");
+							success = true;
+						}
+
+						if (success)
+						{
+							PluginDatabase.RefreshUserData(editData.GameId.ToString());
+							return true;
+						}
+						else
+						{
+							return false;
+						}
+					}
+					catch (Exception ex)
+					{
+						Common.LogError(ex, false, true, PluginDatabase.PluginName);
+						return false;
+					}
+				}
+				catch (Exception ex)
+				{
+					Common.LogError(ex, false, true, PluginDatabase.PluginName);
+					return false;
+				}
+			}
+			else
+			{
+				API.Instance.Notifications.Add(new NotificationMessage(
+					$"{PluginDatabase.PluginName}-DataUpdate-Error",
+					PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
+					NotificationType.Error,
+					() => PluginDatabase.Plugin.OpenSettingsView()
+				));
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Updates the stored cookies for the current user session.
+		/// </summary>
+		public void UpdatedCookies()
+		{
+			try
+			{
+				// Run wait off the UI thread, then invoke UI work when ready
+				FireAndForget(Task.Run(async () =>
+				{
+					var sw = System.Diagnostics.Stopwatch.StartNew();
+					const int maxWaitMs = 60000; // 60s max wait for database load
+					while (!PluginDatabase.IsLoaded)
+					{
+						await Task.Delay(100).ConfigureAwait(false);
+						if (sw.ElapsedMilliseconds > maxWaitMs)
+						{
+							try { if (IsVerboseLoggingEnabled) Logger.Warn("Timeout waiting for PluginDatabase.IsLoaded in UpdatedCookies"); } catch { }
+							break;
+						}
+					}
+
+					try
+					{
+						await Application.Current.Dispatcher.InvokeAsync(() =>
+						{
+							try
+							{
+								if (PluginDatabase.Database.UserHltbData?.UserId != null && PluginDatabase.Database.UserHltbData.UserId != 0)
+								{
+									Logger.Info($"Refresh HowLongToBeat user cookies");
+									List<HttpCookie> cookies = CookiesTools.GetNewWebCookies(new List<string> { UrlBase, UrlUser }, true);
+									_ = CookiesTools.SetStoredCookies(cookies);
+								}
+							}
+							catch (Exception ex)
+							{
+								Common.LogError(ex, false, true, PluginDatabase.PluginName);
+							}
+						});
+					}
+					catch (Exception ex)
+					{
+						Common.LogError(ex, false, true, PluginDatabase.PluginName);
+					}
+				}), "UpdatedCookies");
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+			}
+		}
+
+		/// <summary>
+		/// Try to extract script src URLs using HtmlAgilityPack via reflection. Returns null on failure.
+		/// Reflection is used because HAP is an optional dependency for the host application.
+		/// </summary>
+		private List<string> ExtractScriptUrlsWithHap(string html)
+		{
+			if (!HapAvailable || HapDocType == null || string.IsNullOrEmpty(html))
+			{
+				return null;
+			}
+
+			try
+			{
+				// Create HtmlDocument instance
+				dynamic doc = Activator.CreateInstance(HapDocType);
+				var loadHtml = HapDocType.GetMethod("LoadHtml");
+				loadHtml.Invoke(doc, new object[] { html });
+
+				var documentNode = HapDocType.GetProperty("DocumentNode").GetValue(doc);
+				var selectNodes = documentNode.GetType().GetMethod("SelectNodes", new Type[] { typeof(string) });
+				var nodes = selectNodes.Invoke(documentNode, new object[] { "//script[@src]" }) as System.Collections.IEnumerable;
+				if (nodes == null) return new List<string>();
+
+				var urls = new List<string>();
+				foreach (var node in nodes)
+				{
+					try
+					{
+						var attrsProp = node.GetType().GetProperty("Attributes");
+						if (attrsProp == null) continue;
+						var attrs = attrsProp.GetValue(node);
+						if (attrs == null) continue;
+						var getAttr = attrs.GetType().GetMethod("Get", new Type[] { typeof(string) });
+						if (getAttr == null) continue;
+						var srcAttr = getAttr.Invoke(attrs, new object[] { "src" });
+						if (srcAttr != null)
+						{
+							var valProp = srcAttr.GetType().GetProperty("Value");
+							var val = valProp != null ? valProp.GetValue(srcAttr) as string : null;
+							if (!string.IsNullOrEmpty(val)) urls.Add(val);
+						}
+					}
+					catch { /* ignore per-node errors */ }
+				}
+
+				return urls;
+			}
+			catch (Exception ex)
+			{
+				try { Logger.Warn(ex, "HLTB: HtmlAgilityPack reflection extraction failed"); } catch { }
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Posts JSON payload to URL, optionally with cookies, and returns response string.
+		/// </summary>
+		private async Task<string> PostJson(string url, string payload, List<HttpCookie> cookies = null, CancellationToken cancellationToken = default)
+		{
+			try
+			{
+				HttpClientHandler handler = null;
+				if (cookies != null)
+				{
+					try
+					{
+						var mi = typeof(CommonPluginsShared.Web).GetMethod("CreateCookiesContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+						if (mi != null)
+						{
+							var container = mi.Invoke(null, new object[] { cookies }) as CookieContainer;
+							handler = new HttpClientHandler { CookieContainer = container };
+						}
+					}
+					catch { handler = new HttpClientHandler(); }
+				}
+
+				HttpClient client = null;
+				bool disposeClient = false;
+				try
+				{
+					if (handler != null)
+					{
+						client = new HttpClient(handler)
+						{
+							Timeout = System.Threading.Timeout.InfiniteTimeSpan
+						};
+						disposeClient = true;
+					}
+					else
+					{
+						// Reuse the shared instance-level httpClient to avoid socket exhaustion
+						client = httpClient ?? new HttpClient();
+						disposeClient = false;
+					}
+
+					if (handler != null)
+					{
+						try { client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent); } catch { }
+						try { client.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
+					}
+
+					var content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
+					using (var resp = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false))
+					{
+						if (!resp.IsSuccessStatusCode)
+						{
+							try { Logger.Warn($"HTTP {(int)resp.StatusCode} posting to {url}"); } catch { }
+							return string.Empty;
+						}
+
+						return await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+					}
+				}
+				finally
+				{
+					if (disposeClient && client != null)
+					{
+						try { client.Dispose(); } catch { }
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, $"Error posting to {url}");
+				return string.Empty;
+			}
+		}
+
+		/// <summary>
+		/// Posts JSON payload using shared HttpClient and returns tuple (responseBody, statusCode, retryAfterHeader).
+		/// This is a local replacement for CommonPluginsShared.Web.PostJsonWithSharedClientWithStatus when the submodule isn't available.
+		/// </summary>
+		private async Task<(string body, int status, string retry)> PostJsonWithSharedClientWithStatus(string url, string payload, List<HttpHeader> headers = null, CancellationToken cancellationToken = default)
+		{
+			try
+			{
+				using (var request = new HttpRequestMessage(HttpMethod.Post, url))
+				{
+					request.Content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
+
+					if (headers != null)
+					{
+						foreach (var h in headers)
+						{
+							try
+							{
+								// Try to add to request headers; if invalid, try content headers
+								if (!request.Headers.TryAddWithoutValidation(h.Key, h.Value))
+								{
+									try { request.Content?.Headers.TryAddWithoutValidation(h.Key, h.Value); } catch { }
+								}
+							}
+							catch { }
+						}
+					}
+
+					using (var resp = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
+					{
+						int status = (int)resp.StatusCode;
+						string retry = null;
+						try
+						{
+							if (resp.Headers.TryGetValues("Retry-After", out var vals))
+							{
+								retry = vals.FirstOrDefault();
+							}
+						}
+						catch { }
+
+						string body = string.Empty;
+						try { body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false); } catch { body = string.Empty; }
+
+						if (!resp.IsSuccessStatusCode)
+						{
+							try { Logger.Warn($"HTTP {status} posting to {url}"); } catch { }
+						}
+
+						return (body, status, retry);
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, $"Error posting to {url}");
+				return (string.Empty, 0, (string)null);
+			}
+		}
+		private static readonly Regex _scriptSrcRegex = new Regex("<script[^>]*src=[\\\"']([^\\\"']+)[\\\"'][^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+		private static Regex MyRegex() => _scriptSrcRegex;
+	}
 }

--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -25,3001 +25,2975 @@ using System.Windows;
 
 namespace HowLongToBeat.Services
 {
-	public partial class HowLongToBeatApi : ObservableObject, IDisposable
-	{
-		private static ILogger Logger => LogManager.GetLogger();
-
-		private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
-
-		// Helper to centralize verbose logging checks
-		private static bool IsVerboseLoggingEnabled => PluginDatabase?.PluginSettings?.Settings is HowLongToBeatSettings _vs && _vs.EnableVerboseLogging;
-
-		private void LogDebugVerbose(string message)
-		{
-			try
-			{
-				if (IsVerboseLoggingEnabled)
-				{
-					Logger.Debug(message);
-				}
-			}
-			catch { }
-		}
-
-		private string SafeStr(string s)
-		{
-			try
-			{
-				if (s == null)
-				{
-					return string.Empty;
-				}
-
-				s = s.Replace("\r", " ").Replace("\n", " ");
-				return s.Length > 120 ? s.Substring(0, 120) + "..." : s;
-			}
-			catch
-			{
-				return string.Empty;
-			}
-		}
-
-		private DateTime lastLoginCheckUtc = DateTime.MinValue;
-		private bool? lastLoginCheckResult = null;
-
-		private void LogCookieSummary(string context, List<HttpCookie> cookies)
-		{
-			try
-			{
-				if (!IsVerboseLoggingEnabled)
-				{
-					return;
-				}
-
-				cookies = cookies ?? new List<HttpCookie>();
-				var domains = cookies.Select(c => c?.Domain ?? string.Empty).Where(d => !string.IsNullOrEmpty(d)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-
-				int expiredCount = 0;
-				DateTime? minExpiry = null;
-				DateTime? maxExpiry = null;
-				foreach (var c in cookies)
-				{
-					if (c?.Expires is DateTime dt)
-					{
-						if (dt <= DateTime.Now)
-						{
-							expiredCount++;
-						}
-
-						if (minExpiry == null || dt < minExpiry) minExpiry = dt;
-						if (maxExpiry == null || dt > maxExpiry) maxExpiry = dt;
-					}
-				}
-
-				Logger.Debug($"HLTB Auth: {context} cookies={cookies.Count} expired={expiredCount} domains=[{string.Join(",", domains)}] minExp={(minExpiry?.ToString("o") ?? "<none>")} maxExp={(maxExpiry?.ToString("o") ?? "<none>")}");
-			}
-			catch { }
-		}
-
-		private void FireAndForget(Task task, string context)
-		{
-			// Delegate to centralized helper to avoid duplication with HowLongToBeatDatabase
-			try
-			{
-				TaskHelpers.FireAndForget(task, context, LogManager.GetLogger());
-			}
-			catch { }
-		}
-
-		/// <summary>
-		/// Adjusts a semaphore to match a target limit by releasing extra permits or consuming existing permits.
-		/// The helper reads and writes the shared current limit via the provided delegates under the provided syncLock
-		/// to avoid races where callers supply stale snapshots. The method returns once adjustments are applied.
-		/// </summary>
-		private async Task AdjustSemaphoreLimit(
-			SemaphoreSlim semaphore,
-			Func<int> getCurrentLimit,
-			Action<int> setCurrentLimit,
-			int targetLimit,
-			object syncLock,
-			string context = null,
-			CancellationToken cancellationToken = default)
-		{
-			if (semaphore == null) return;
-
-			try
-			{
-				int pendingConsume = 0;
-
-				targetLimit = Math.Max(0, Math.Min(SemaphoreUpperBound, targetLimit));
-
-				// Compute difference under lock and handle immediate increases (release permits)
-				if (syncLock == null)
-				{
-					try { Logger.Warn("HLTB: AdjustSemaphoreLimit called with null syncLock; using internal lock"); } catch { }
-					syncLock = new object();
-				}
-
-				int current = getCurrentLimit();
-				int diff;
-				lock (syncLock)
-				{
-					current = getCurrentLimit();
-					diff = targetLimit - current;
-					if (diff > 0)
-					{
-						bool released = false;
-						try
-						{
-							semaphore.Release(diff);
-							released = true;
-						}
-						catch (Exception ex)
-						{
-							try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit failed to release {diff} permits (currentLimit={current}) ({context})"); } catch { }
-						}
-
-						try
-						{
-							if (released)
-							{
-								try { setCurrentLimit(targetLimit); } catch { }
-							}
-						}
-						catch { }
-
-						if (released) return;
-					}
-
-					if (diff < 0)
-					{
-						pendingConsume = -diff; // how many permits we need to consume to lower the available count
-					}
-				}
-
-				if (pendingConsume > 0)
-				{
-					// Try to consume up to pendingConsume permits with short, bounded waits so no orphaned tasks remain.
-					int consumed = 0;
-					TimeSpan tryWait = TimeSpan.FromMilliseconds(200);
-
-					for (int i = 0; i < pendingConsume; i++)
-					{
-						try
-						{
-							if (cancellationToken.IsCancellationRequested)
-							{
-								break;
-							}
-							bool got = await semaphore.WaitAsync(tryWait, cancellationToken).ConfigureAwait(false);
-							if (!got)
-							{
-								break; // timed out acquiring next permit; stop trying
-							}
-
-							consumed++;
-						}
-						catch (OperationCanceledException)
-						{
-							break;
-						}
-						catch
-						{
-							break;
-						}
-					}
-
-					// Update the shared currentLimit under lock based on how many permits we actually consumed
-					lock (syncLock)
-					{
-						int originalLimit = getCurrentLimit();
-						int newLimit;
-
-						if (consumed == pendingConsume)
-						{
-							// Successfully consumed all intended permits
-							newLimit = targetLimit;
-						}
-						else
-						{
-							// We consumed fewer than requested; lower the limit by the number we consumed (but not below 0)
-							newLimit = Math.Max(0, originalLimit - consumed);
-							// Ensure we don't accidentally increase above originalLimit
-							newLimit = Math.Min(originalLimit, newLimit);
-						}
-
-						setCurrentLimit(newLimit);
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit error ({context})"); } catch { }
-			}
-		}
-
-
-		/// <summary>
-		/// Tool for managing cookies for HowLongToBeat sessions.
-		/// </summary>
-		protected CookiesTools CookiesTools { get; }
-		/// <summary>
-		/// List of domains for which cookies are managed.
-		/// </summary>
-		protected List<string> CookiesDomains { get; }
-		/// <summary>
-		/// Path to the file where cookies are stored.
-		/// </summary>
-		internal string FileCookies { get; }
-
-		private readonly Type HapDocType;
-		private readonly bool HapAvailable;
-
-		private static string SearchUrl { get; set; } = null;
-		private static readonly object SearchUrlLock = new object();
-		private const int ScriptDownloadTimeoutMs = 5000;
-
-		private const int MaxParallelGameDataDownloads = 32;
-		private const int GameDataDownloadTimeoutMs = 15000;
-
-		private const int MaxParallelSearches = 96;
-
-		// Replace unbounded dictionaries with bounded LRU caches to avoid unbounded memory growth
-		private readonly LruCache<string, string> GamePageCache;
-		private readonly LruCache<string, SearchResult> SearchCache;
-		private SemaphoreSlim SearchSemaphore;
-		private AdaptiveConcurrencyController SearchConcurrencyController;
-		private readonly object SearchConcurrencySync = new object();
-		private int CurrentSearchLimit;
-		private int PersistentCacheHits = 0;
-		private int InMemoryCacheHits = 0;
-		private int PageFetches = 0;
-		private PageCache PageCache;
-		private AdaptiveConcurrencyController ConcurrencyController;
-		private SemaphoreSlim DynamicSemaphore;
-		private readonly object ConcurrencySync = new object();
-		private int CurrentSemaphoreLimit;
-		private const int SemaphoreUpperBound = 128;
-
-		private readonly HttpClient httpClient;
-		private Task PageCacheInitTask;
-		// Thread-local Random to provide jitter without creating many Sequential Random instances
-		private static readonly ThreadLocal<Random> _rnd = new ThreadLocal<Random>(() => new Random(Guid.NewGuid().GetHashCode()));
-
-		private readonly ConcurrentQueue<long> RecentSearchSamples = new ConcurrentQueue<long>();
-		private const int RecentSamplesWindow = 200;
-
-		private readonly ConcurrentQueue<int> RecentSearchStatusCodes = new ConcurrentQueue<int>();
-		private const int RecentStatusWindow = 200;
-
-		private DateTime SearchBackoffUntil = DateTime.MinValue;
-		private int SearchBackoffLimit = 0;
-		private readonly object BackoffSync = new object();
-
-		private string CachedAuthToken = null;
-		private DateTime CachedAuthTokenExpiry = DateTime.MinValue;
-		private readonly object AuthTokenSync = new object();
-
-		private CancellationTokenSource monitorCts;
-		private Task monitorTask;
-		private readonly object monitorSync = new object();
-		private bool _disposed = false;
-
-
-		#region Urls
-
-		private static string UrlBase => "https://howlongtobeat.com";
-
-		private static string UrlLogin => UrlBase + "/login";
-		private static string UrlLogOut => UrlBase + "/login?t=out";
-		private static string UrlSearchWeb => UrlBase + "/?q={0}";
-
-		private static string UrlUser => UrlBase + "/api/user";
-		private static string UrlUserStats => UrlUser + "?n={0}&s=stats";
-		private static string UrlUserStatsMore => UrlBase + "/user_stats_more";
-		private static string UrlUserStatsGamesList => UrlUser + "/{0}/stats";
-		private static string UrlUserGamesList => UrlUser + "/{0}/games/list";
-		private static string UrlUserStatsGameDetails => UrlBase + "/user_games_detail";
-
-		private static string UrlPostData => UrlBase + "/api/submit";
-		private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
-
-		private static string SearchEndPoint => "/api/locate";
-		private static string UrlSearch => UrlBase + SearchEndPoint;
-
-		private static string UrlGameImg => UrlBase + "/games/{0}";
-
-		private static string UrlGame => UrlBase + "/game?id={0}";
-
-		private static string UrlExportAll => UrlBase + "/user_export?all=1";
-
-		#endregion
-
-
-		private bool? _isConnected = null;
-		/// <summary>
-		/// Indicates if the user is currently connected (logged in).
-		/// </summary>
-		public bool? IsConnected { get => _isConnected; set => SetValue(ref _isConnected, value); }
-
-		/// <summary>
-		/// The username of the currently logged-in user.
-		/// </summary>
-		public string UserLogin { get; set; } = string.Empty;
-		/// <summary>
-		/// The user ID of the currently logged-in user.
-		/// </summary>
-		public int UserId { get; set; } = 0;
-
-		private bool IsFirst = true;
-
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="HowLongToBeatApi"/> class.
-		/// </summary>
-		public HowLongToBeatApi()
-		{
-			try
-			{
-				var handler = new HttpClientHandler();
-				var prop = handler.GetType().GetProperty("MaxConnectionsPerServer");
-				if (prop != null && prop.CanWrite)
-				{
-					prop.SetValue(handler, Math.Max(4, MaxParallelGameDataDownloads));
-				}
-				else
-				{
-					Logger.Warn("HLTB: MaxConnectionsPerServer not available; using default connection limits");
-				}
-
-				httpClient = new HttpClient(handler)
-				{
-					Timeout = System.Threading.Timeout.InfiniteTimeSpan
-				};
-				httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent);
-				try { httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", UrlBase); } catch { }
-				try { httpClient.DefaultRequestHeaders.Add("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
-			}
-			catch (Exception ex)
-			{
-				Logger.Error(ex, "HLTB: HttpClient init failed");
-				throw;
-			}
-
-			// Create default alias file if missing (non-fatal)
-			try
-			{
-				GameNameAliases.EnsureAliasFileExists(PluginDatabase?.Plugin?.GetPluginUserDataPath());
-			}
-			catch { }
-
-			// Cache HtmlAgilityPack availability once to avoid reflection on every request.
-			Type hapType = null;
-			try
-			{
-				hapType = Type.GetType("HtmlAgilityPack.HtmlDocument, HtmlAgilityPack");
-			}
-			catch { }
-			HapDocType = hapType;
-			HapAvailable = HapDocType != null;
-
-			UserLogin = PluginDatabase.PluginSettings.Settings.UserLogin;
-
-			CookiesDomains = new List<string>
-			{
-				".howlongtobeat.com",
-				"howlongtobeat.com",
-				"www.howlongtobeat.com",
-				".www.howlongtobeat.com"
-			};
-			string pathData = PluginDatabase.Paths.PluginUserDataPath;
-			FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.dat"));
-			CookiesTools = new CookiesTools(
-				PluginDatabase.PluginName,
-				"HowLongToBeat",
-				FileCookies,
-				CookiesDomains
-			);
-
-			try
-			{
-				var exists = File.Exists(FileCookies);
-				long size = 0;
-				if (exists)
-				{
-					try { size = new FileInfo(FileCookies).Length; } catch { }
-				}
-
-				Logger.Info($"HLTB Auth: cookie file='{FileCookies}' exists={exists} size={size}");
-				if (exists)
-				{
-					var stored = CookiesTools.GetStoredCookies();
-					LogCookieSummary("startup stored", stored);
-
-					// Non-critical: validate cookies on startup to help diagnose "logged out after restart".
-					FireAndForget(Task.Run(async () =>
-					{
-						try
-						{
-							await Task.Delay(2000).ConfigureAwait(false);
-							bool ok = await GetIsUserLoggedInAsync().ConfigureAwait(false);
-							Logger.Info($"HLTB Auth: startup cookie check ok={ok} userId={UserId}");
-						}
-						catch (Exception ex)
-						{
-							try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-						}
-					}), "startup cookie check");
-				}
-			}
-			catch { }
-
-			try
-			{
-				PageCacheInitTask = Task.Run(() =>
-				{
-					PageCache localPc = null;
-					try
-					{
-						localPc = new PageCache(PluginDatabase.Plugin.GetPluginUserDataPath());
-						if (!_disposed)
-						{
-							PageCache = localPc;
-							localPc = null;
-						}
-						else
-						{
-							try { (localPc as IDisposable)?.Dispose(); } catch { }
-							localPc = null;
-						}
-					}
-					catch (Exception ex)
-					{
-						Common.LogError(ex, false);
-						try { Logger.Warn("HLTB: PageCache init failed; proceeding without persistent cache"); } catch { }
-						if (localPc != null)
-						{
-							try { (localPc as IDisposable)?.Dispose(); } catch { }
-							localPc = null;
-						}
-					}
-				});
-
-				// Observe any exceptions from the init task so they don't go unobserved
-				PageCacheInitTask.ContinueWith(t =>
-				{
-					try
-					{
-						if (t.IsFaulted && t.Exception != null)
-						{
-							Common.LogError(t.Exception, false);
-						}
-					}
-					catch { }
-				}, TaskContinuationOptions.OnlyOnFaulted);
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false);
-			}
-
-			// Configure bounded in-memory caches to avoid unbounded growth during large imports
-			// Sizes are conservative defaults; can be tuned via settings later.
-			GamePageCache = new LruCache<string, string>(capacity: 2000, ttl: TimeSpan.FromHours(6));
-			SearchCache = new LruCache<string, SearchResult>(capacity: 2000, ttl: TimeSpan.FromHours(6));
-
-			try
-			{
-				ConcurrencyController = new AdaptiveConcurrencyController(MaxParallelGameDataDownloads, 4, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
-				DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads, SemaphoreUpperBound);
-				CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
-				try
-				{
-					SearchConcurrencyController = new AdaptiveConcurrencyController(MaxParallelSearches, 2, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
-					CurrentSearchLimit = MaxParallelSearches;
-					SearchSemaphore = new SemaphoreSlim(MaxParallelSearches, SemaphoreUpperBound);
-				}
-				catch (Exception ex)
-				{
-					try { Logger.Warn(ex, "HLTB: Search concurrency controller init failed; using basic semaphore"); } catch { }
-					SearchSemaphore = new SemaphoreSlim(MaxParallelSearches);
-					CurrentSearchLimit = MaxParallelSearches;
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false);
-				try { Logger.Warn("HLTB: Adaptive concurrency init failed; using basic semaphore defaults"); } catch { }
-				DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads);
-				CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
-			}
-
-		}
-
-		public void StopMonitoring()
-		{
-			try
-			{
-				var task = monitorTask;
-				var cts = monitorCts;
-
-				try { cts?.Cancel(); } catch { }
-
-				if (task != null)
-				{
-					try { task.Wait(5000); } catch { }
-				}
-
-				try { cts?.Dispose(); } catch { }
-				monitorCts = null;
-				monitorTask = null;
-			}
-			catch { }
-		}
-
-		private void EnsureMonitoringStarted()
-		{
-			if (_disposed) return;
-			lock (monitorSync)
-			{
-				if (monitorTask != null && !monitorTask.IsCompleted && monitorCts != null && !monitorCts.IsCancellationRequested)
-				{
-					return;
-				}
-
-				try { monitorCts?.Dispose(); } catch { }
-				monitorCts = new CancellationTokenSource();
-				try
-				{
-					monitorTask = Task.Run(async () =>
-					{
-						var token = monitorCts.Token;
-						try
-						{
-							while (!token.IsCancellationRequested)
-							{
-								try
-								{
-									if (token.IsCancellationRequested) break;
-									await Task.Delay(TimeSpan.FromSeconds(10), token).ConfigureAwait(false);
-								}
-								catch (OperationCanceledException)
-								{
-									break;
-								}
-								catch (Exception) { }
-								try
-								{
-									int searchTarget;
-									bool searchForced = false;
-									try
-									{
-										int fixedTarget = MaxParallelSearches;
-										lock (BackoffSync)
-										{
-											if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
-											{
-												searchTarget = Math.Min(fixedTarget, SearchBackoffLimit);
-											}
-											else
-											{
-												searchTarget = fixedTarget;
-											}
-										}
-										searchForced = true;
-									}
-									catch
-									{
-										searchTarget = SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
-									}
-
-									int searchAvailable = 0;
-									int searchInFlight = 0;
-									int gameTarget = 0;
-									int gameAvailable = 0;
-									int gameInFlight = 0;
-									try
-									{
-										searchAvailable = SearchSemaphore?.CurrentCount ?? 0;
-										searchInFlight = Math.Max(0, searchTarget - searchAvailable);
-
-										gameTarget = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-										gameAvailable = DynamicSemaphore?.CurrentCount ?? 0;
-										gameInFlight = Math.Max(0, gameTarget - gameAvailable);
-									}
-									catch (ObjectDisposedException) { break; }
-									catch (InvalidOperationException) { break; }
-
-									var samples = RecentSearchSamples.ToArray();
-									double avg = samples.Length > 0 ? samples.Average() : 0;
-									double median = 0;
-									double p90 = 0;
-									if (samples.Length > 0)
-									{
-										var ordered = samples.OrderBy(x => x).ToArray();
-										median = ordered[ordered.Length / 2];
-										p90 = ordered[Math.Max(0, (int)Math.Floor(ordered.Length * 0.9) - 1)];
-									}
-
-									LogDebugVerbose($"HLTB Summary: searchTarget={searchTarget} searchInFlight={searchInFlight} gameTarget={gameTarget} gameInFlight={gameInFlight} avgSearchMs={Math.Round(avg, 1)} medianSearchMs={Math.Round(median, 1)} p90SearchMs={Math.Round(p90, 1)} persistentCacheHits={PersistentCacheHits} inMemoryCacheHits={InMemoryCacheHits} pageFetches={PageFetches} forced={searchForced}");
-								}
-								catch (Exception ex)
-								{
-									try { Logger.Error(ex, "HLTB monitor loop error"); } catch { }
-								}
-							}
-						}
-						catch (Exception ex)
-						{
-							try { Logger.Error(ex, "HLTB monitor task terminated unexpectedly"); } catch { }
-						}
-					});
-				}
-				catch (Exception ex)
-				{
-					try { Logger.Error(ex, "Failed to start HLTB monitor task"); } catch { }
-				}
-			}
-		}
-
-		~HowLongToBeatApi()
-		{
-			try { Dispose(false); } catch { }
-		}
-
-		public void Dispose()
-		{
-			Dispose(true);
-			try { GC.SuppressFinalize(this); } catch { }
-		}
-
-		protected virtual void Dispose(bool disposing)
-		{
-			if (_disposed) return;
-
-			_disposed = true;
-
-			if (disposing)
-			{
-				try
-				{
-					// Use StopMonitoring as single shutdown path; it will cancel and cleanup without blocking.
-					try { StopMonitoring(); } catch { }
-				}
-				catch { }
-				finally
-				{
-					monitorTask = null;
-					monitorCts = null;
-				}
-
-				try { ConcurrencyController?.Dispose(); } catch { }
-				ConcurrencyController = null;
-				try { SearchConcurrencyController?.Dispose(); } catch { }
-				SearchConcurrencyController = null;
-
-				try { DynamicSemaphore?.Dispose(); } catch { }
-				DynamicSemaphore = null;
-				try { SearchSemaphore?.Dispose(); } catch { }
-				SearchSemaphore = null;
-
-				try { httpClient?.Dispose(); } catch { }
-
-				// Dispose page cache if it implements IDisposable
-				try
-				{
-					if (PageCache is IDisposable disposableCache)
-					{
-						try { disposableCache.Dispose(); } catch { }
-					}
-				}
-				catch { }
-				PageCache = null;
-			}
-		}
-
-
-		/// <summary>
-		/// Retrieves game data from HowLongToBeat by game ID.
-		/// </summary>
-		/// <param name="id">The game ID.</param>
-		/// <returns>Returns <see cref="HltbData"/> with game times, or null if not found.</returns>
-		private async Task<HltbData> GetGameData(string id, CancellationToken cancellationToken = default)
-		{
-			try { EnsureMonitoringStarted(); } catch { }
-			cancellationToken.ThrowIfCancellationRequested();
-			try
-			{
-				var init = PageCacheInitTask;
-				if (init != null && PageCache == null)
-				{
-					await Task.WhenAny(init, Task.Delay(500)).ConfigureAwait(false);
-				}
-			}
-			catch { }
-			DateTime startTime = DateTime.UtcNow;
-			LogDebugVerbose($"GetGameData START id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} time={startTime:HH:mm:ss.fff}");
-
-			try
-			{
-				string jsonData = null;
-				try
-				{
-					if (PageCache != null && PageCache.TryGetJson(id, out string cachedJson))
-					{
-						jsonData = cachedJson;
-						try { System.Threading.Interlocked.Increment(ref PersistentCacheHits); } catch { }
-						LogDebugVerbose($"GetGameData id={id} - persistent cache hit");
-					}
-				}
-				catch (Exception ex)
-				{
-					Common.LogError(ex, false, false, PluginDatabase.PluginName);
-				}
-
-				int attempts = 0;
-				if (string.IsNullOrEmpty(jsonData))
-				{
-					string response = string.Empty;
-					int maxAttempts = 3;
-					int baseDelayMs = 300;
-					var rnd = _rnd.Value;
-					while (attempts < maxAttempts)
-					{
-						attempts++;
-						try
-						{
-							cancellationToken.ThrowIfCancellationRequested();
-							if (GamePageCache.TryGetValue(id, out string cached))
-							{
-								response = cached;
-								try { System.Threading.Interlocked.Increment(ref InMemoryCacheHits); } catch { }
-								LogDebugVerbose($"GetGameData id={id} - in-memory cache hit");
-							}
-							else
-							{
-								try
-								{
-									using (var httpResp = await httpClient.GetAsync(string.Format(UrlGame, id), cancellationToken).ConfigureAwait(false))
-									{
-										if (!httpResp.IsSuccessStatusCode)
-										{
-											var code = (int)httpResp.StatusCode;
-											LogDebugVerbose($"GetGameData id={id} - HTTP {code} fetching page");
-											response = string.Empty;
-										}
-										else
-										{
-											response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
-										}
-									}
-								}
-								catch (HttpRequestException hre)
-								{
-									Common.LogError(hre, false, false, PluginDatabase.PluginName);
-									response = string.Empty;
-								}
-							}
-
-							if (!response.IsNullOrEmpty())
-							{
-								string maybeJson = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
-								if (!maybeJson.IsNullOrEmpty())
-								{
-									GamePageCache.TryAdd(id, response);
-									try
-									{
-										PageCache?.Set(id, maybeJson);
-									}
-									catch (Exception ex)
-									{
-										Common.LogError(ex, false, false, PluginDatabase.PluginName);
-									}
-									try { System.Threading.Interlocked.Increment(ref PageFetches); } catch { }
-									jsonData = maybeJson;
-									break;
-								}
-								else
-								{
-									Common.LogDebug(true, $"GetGameData id={id} - extracted JSON was empty or incomplete (attempt={attempts})");
-									response = string.Empty;
-								}
-							}
-						}
-						catch (Exception ex)
-						{
-							Common.LogError(ex, false, false, PluginDatabase.PluginName);
-						}
-
-						if (attempts < maxAttempts)
-						{
-							var jitter = rnd.Next(0, 200);
-							var delay = baseDelayMs * attempts + jitter;
-							LogDebugVerbose($"GetGameData id={id} - retry {attempts} after {delay}ms");
-							try { await Task.Delay(delay, cancellationToken); } catch (OperationCanceledException) { throw; }
-						}
-					}
-				}
-				if (string.IsNullOrEmpty(jsonData))
-				{
-					Common.LogDebug(true, $"GetGameData id={id} - no JSON extracted after {attempts} attempts");
-					Logger.Warn($"No GameData find with {id}");
-					double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-					try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
-					LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
-					return null;
-				}
-
-				_ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
-				if (parseEx != null)
-				{
-					Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
-				}
-
-				GameData gameData = next_data?.Props?.PageProps?.Game?.Data?.Game != null
-					? next_data.Props.PageProps.Game.Data.Game.FirstOrDefault()
-					: null;
-
-				if (gameData != null)
-				{
-					HltbData hltbData = new HltbData
-					{
-						MainStoryClassic = gameData.CompMain,
-						MainExtraClassic = gameData.CompPlus,
-						CompletionistClassic = gameData.Comp100,
-						SoloClassic = gameData.CompAll,
-						CoOpClassic = gameData.InvestedCo,
-						VsClassic = gameData.InvestedMp,
-
-						MainStoryMedian = gameData.CompMainMed,
-						MainExtraMedian = gameData.CompPlusMed,
-						CompletionistMedian = gameData.Comp100Med,
-						SoloMedian = gameData.CompAllMed,
-						CoOpMedian = gameData.InvestedCoMed,
-						VsMedian = gameData.InvestedMpMed,
-
-						MainStoryAverage = gameData.CompMainAvg,
-						MainExtraAverage = gameData.CompPlusAvg,
-						CompletionistAverage = gameData.Comp100Avg,
-						SoloAverage = gameData.CompAllAvg,
-						CoOpAverage = gameData.InvestedCoAvg,
-						VsAverage = gameData.InvestedMpAvg,
-
-						MainStoryRushed = gameData.CompMainL,
-						MainExtraRushed = gameData.CompPlusL,
-						CompletionistRushed = gameData.Comp100L,
-						SoloRushed = gameData.CompAllL,
-						CoOpRushed = gameData.InvestedCoL,
-						VsRushed = gameData.InvestedMpL,
-
-						MainStoryLeisure = gameData.CompMainH,
-						MainExtraLeisure = gameData.CompPlusH,
-						CompletionistLeisure = gameData.Comp100H,
-						SoloLeisure = gameData.CompAllH,
-						CoOpLeisure = gameData.InvestedCoH,
-						VsLeisure = gameData.InvestedMpH
-					};
-
-					double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-					try { ConcurrencyController?.ReportSample(elapsed, true); } catch { }
-					LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
-					return hltbData;
-				}
-				else
-				{
-					Logger.Warn($"No GameData find with {id}");
-					double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
-					try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
-					LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
-					return null;
-				}
-			}
-			catch (OperationCanceledException)
-			{
-				throw;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				Logger.Info($"GetGameData ERROR id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={(DateTime.UtcNow - startTime).TotalMilliseconds}ms");
-			}
-
-			return null;
-		}
-
-		/// <summary>
-		/// Updates the HLTB data for a user game entry.
-		/// </summary>
-		/// <param name="hltbDataUser">The user game data to update.</param>
-		/// <returns>Returns the updated <see cref="HltbDataUser"/>.</returns>
-		public async Task<HltbDataUser> UpdateGameData(HltbDataUser hltbDataUser)
-		{
-			try
-			{
-				HltbData hltbData = await GetGameData(hltbDataUser.Id);
-				hltbDataUser.GameHltbData = hltbData ?? hltbDataUser.GameHltbData;
-				return hltbDataUser;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				return null;
-			}
-		}
-
-
-		#region Search
-
-		/// <summary>
-		/// Retrieves the search URL from the website scripts.
-		/// </summary>
-		/// <returns>The search endpoint URL.</returns>
-		private async Task<string> GetSearchUrl()
-		{
-			return "/api/find";
-			if (!SearchUrl.IsNullOrEmpty() && !SearchUrl.Contains("error"))
-			{
-				return SearchUrl;
-			}
-
-			try
-			{
-				string url = UrlBase;
-
-				string response = null;
-				using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
-				{
-					try
-					{
-						using (var httpResp = await httpClient.GetAsync(url, cts.Token).ConfigureAwait(false))
-						{
-							if (!httpResp.IsSuccessStatusCode)
-							{
-								try { Logger.Warn($"HTTP {(int)httpResp.StatusCode} downloading {url}"); } catch { }
-								return "/api/s";
-							}
-
-							response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
-						}
-					}
-					catch (TaskCanceledException)
-					{
-						try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {url}"); } catch { }
-						return "/api/s";
-					}
-					catch (Exception ex)
-					{
-						Common.LogError(ex, false, true, PluginDatabase.PluginName);
-						return "/api/s";
-					}
-				}
-
-				// Try to extract script URLs via optional HtmlAgilityPack helper (reflection). Fall back to regex if unavailable.
-				List<string> scriptUrls = ExtractScriptUrlsWithHap(response) ?? new List<string>();
-				if (scriptUrls.Count == 0)
-				{
-
-					var matches = MyRegex().Matches(response);
-					foreach (Match match in matches)
-					{
-						scriptUrls.Add(match.Groups[1].Value);
-					}
-				}
-
-				var ordered = scriptUrls.Where(s => s.Contains("_app-")).Concat(scriptUrls).Where(s => !string.IsNullOrEmpty(s)).Distinct();
-				foreach (string sUrl in ordered)
-				{
-					string scriptUrl = sUrl;
-					if (!scriptUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-					{
-						scriptUrl = UrlBase + scriptUrl;
-					}
-
-					string scriptContent = null;
-					using (var ctsScript = new CancellationTokenSource(ScriptDownloadTimeoutMs))
-					{
-						try
-						{
-							using (var scriptResp = await httpClient.GetAsync(scriptUrl, ctsScript.Token).ConfigureAwait(false))
-							{
-								if (!scriptResp.IsSuccessStatusCode)
-								{
-									try { Logger.Warn($"HTTP {(int)scriptResp.StatusCode} downloading {scriptUrl}"); } catch { }
-									continue;
-								}
-
-								scriptContent = await scriptResp.Content.ReadAsStringAsync().ConfigureAwait(false);
-							}
-						}
-						catch (TaskCanceledException)
-						{
-							try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {scriptUrl}"); } catch { }
-							continue;
-						}
-						catch (Exception ex)
-						{
-							Common.LogError(ex, false, true, PluginDatabase.PluginName);
-							continue;
-						}
-					}
-
-					string pattern = "fetch\\s*\\(\\s*[\"']\\/api\\/([a-zA-Z0-9_\\/]+)[^\"']*[\"']\\s*,\\s*\\{[^}]*method:\\s*[\"']POST[\"'][^}]*\\}";
-					var searchMatch = Regex.Match(scriptContent, pattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
-					if (searchMatch.Success)
-					{
-						string suffix = searchMatch.Groups[1].Value;
-						if (suffix.Contains("/"))
-						{
-							suffix = suffix.Split('/')[0];
-						}
-
-						if (suffix != "find")
-						{
-							lock (SearchUrlLock)
-							{
-								if (SearchUrl.IsNullOrEmpty())
-								{
-									SearchUrl = "/api/" + suffix;
-								}
-							}
-							return SearchUrl;
-						}
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-			}
-
-			return "/api/s";
-		}
+    public partial class HowLongToBeatApi : ObservableObject, IDisposable
+    {
+        private static ILogger Logger => LogManager.GetLogger();
+
+        private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
+
+        // Helper to centralize verbose logging checks
+        private static bool IsVerboseLoggingEnabled => PluginDatabase?.PluginSettings?.Settings is HowLongToBeatSettings _vs && _vs.EnableVerboseLogging;
+
+        private void LogDebugVerbose(string message)
+        {
+            try
+            {
+                if (IsVerboseLoggingEnabled)
+                {
+                    Logger.Debug(message);
+                }
+            }
+            catch { }
+        }
+
+        private string SafeStr(string s)
+        {
+            try
+            {
+                if (s == null)
+                {
+                    return string.Empty;
+                }
+
+                s = s.Replace("\r", " ").Replace("\n", " ");
+                return s.Length > 120 ? s.Substring(0, 120) + "..." : s;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private DateTime lastLoginCheckUtc = DateTime.MinValue;
+        private bool? lastLoginCheckResult = null;
+
+        private void LogCookieSummary(string context, List<HttpCookie> cookies)
+        {
+            try
+            {
+                if (!IsVerboseLoggingEnabled)
+                {
+                    return;
+                }
+
+                cookies = cookies ?? new List<HttpCookie>();
+                var domains = cookies.Select(c => c?.Domain ?? string.Empty).Where(d => !string.IsNullOrEmpty(d)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+                int expiredCount = 0;
+                DateTime? minExpiry = null;
+                DateTime? maxExpiry = null;
+                foreach (var c in cookies)
+                {
+                    if (c?.Expires is DateTime dt)
+                    {
+                        if (dt <= DateTime.Now)
+                        {
+                            expiredCount++;
+                        }
+
+                        if (minExpiry == null || dt < minExpiry) minExpiry = dt;
+                        if (maxExpiry == null || dt > maxExpiry) maxExpiry = dt;
+                    }
+                }
+
+                Logger.Debug($"HLTB Auth: {context} cookies={cookies.Count} expired={expiredCount} domains=[{string.Join(",", domains)}] minExp={(minExpiry?.ToString("o") ?? "<none>")} maxExp={(maxExpiry?.ToString("o") ?? "<none>")}");
+            }
+            catch { }
+        }
+
+        private void FireAndForget(Task task, string context)
+        {
+            // Delegate to centralized helper to avoid duplication with HowLongToBeatDatabase
+            try
+            {
+                TaskHelpers.FireAndForget(task, context, LogManager.GetLogger());
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Adjusts a semaphore to match a target limit by releasing extra permits or consuming existing permits.
+        /// The helper reads and writes the shared current limit via the provided delegates under the provided syncLock
+        /// to avoid races where callers supply stale snapshots. The method returns once adjustments are applied.
+        /// </summary>
+        private async Task AdjustSemaphoreLimit(
+            SemaphoreSlim semaphore,
+            Func<int> getCurrentLimit,
+            Action<int> setCurrentLimit,
+            int targetLimit,
+            object syncLock,
+            string context = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (semaphore == null) return;
+
+            try
+            {
+                int pendingConsume = 0;
+
+                targetLimit = Math.Max(0, Math.Min(SemaphoreUpperBound, targetLimit));
+
+                // Compute difference under lock and handle immediate increases (release permits)
+                if (syncLock == null)
+                {
+                    try { Logger.Warn("HLTB: AdjustSemaphoreLimit called with null syncLock; using internal lock"); } catch { }
+                    syncLock = new object();
+                }
+
+                int current = getCurrentLimit();
+                int diff;
+                lock (syncLock)
+                {
+                    current = getCurrentLimit();
+                    diff = targetLimit - current;
+                    if (diff > 0)
+                    {
+                        bool released = false;
+                        try
+                        {
+                            semaphore.Release(diff);
+                            released = true;
+                        }
+                        catch (Exception ex)
+                        {
+                            try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit failed to release {diff} permits (currentLimit={current}) ({context})"); } catch { }
+                        }
+
+                        try
+                        {
+                            if (released)
+                            {
+                                try { setCurrentLimit(targetLimit); } catch { }
+                            }
+                        }
+                        catch { }
+
+                        if (released) return;
+                    }
+
+                    if (diff < 0)
+                    {
+                        pendingConsume = -diff; // how many permits we need to consume to lower the available count
+                    }
+                }
+
+                if (pendingConsume > 0)
+                {
+                    // Try to consume up to pendingConsume permits with short, bounded waits so no orphaned tasks remain.
+                    int consumed = 0;
+                    TimeSpan tryWait = TimeSpan.FromMilliseconds(200);
+
+                    for (int i = 0; i < pendingConsume; i++)
+                    {
+                        try
+                        {
+                            if (cancellationToken.IsCancellationRequested)
+                            {
+                                break;
+                            }
+                            bool got = await semaphore.WaitAsync(tryWait, cancellationToken).ConfigureAwait(false);
+                            if (!got)
+                            {
+                                break; // timed out acquiring next permit; stop trying
+                            }
+
+                            consumed++;
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+                        catch
+                        {
+                            break;
+                        }
+                    }
+
+                    // Update the shared currentLimit under lock based on how many permits we actually consumed
+                    lock (syncLock)
+                    {
+                        int originalLimit = getCurrentLimit();
+                        int newLimit;
+
+                        if (consumed == pendingConsume)
+                        {
+                            // Successfully consumed all intended permits
+                            newLimit = targetLimit;
+                        }
+                        else
+                        {
+                            // We consumed fewer than requested; lower the limit by the number we consumed (but not below 0)
+                            newLimit = Math.Max(0, originalLimit - consumed);
+                            // Ensure we don't accidentally increase above originalLimit
+                            newLimit = Math.Min(originalLimit, newLimit);
+                        }
+
+                        setCurrentLimit(newLimit);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                try { Logger.Warn(ex, $"HLTB: AdjustSemaphoreLimit error ({context})"); } catch { }
+            }
+        }
+
+
+        /// <summary>
+        /// Tool for managing cookies for HowLongToBeat sessions.
+        /// </summary>
+        protected CookiesTools CookiesTools { get; }
+        /// <summary>
+        /// List of domains for which cookies are managed.
+        /// </summary>
+        protected List<string> CookiesDomains { get; }
+        /// <summary>
+        /// Path to the file where cookies are stored.
+        /// </summary>
+        internal string FileCookies { get; }
+
+        private readonly Type HapDocType;
+        private readonly bool HapAvailable;
+
+        private static string SearchUrl { get; set; } = null;
+        private static readonly object SearchUrlLock = new object();
+        private const int ScriptDownloadTimeoutMs = 5000;
+
+        private const int MaxParallelGameDataDownloads = 32;
+        private const int GameDataDownloadTimeoutMs = 15000;
+
+        private const int MaxParallelSearches = 96;
+
+        // Replace unbounded dictionaries with bounded LRU caches to avoid unbounded memory growth
+        private readonly LruCache<string, string> GamePageCache;
+        private readonly LruCache<string, SearchResult> SearchCache;
+        private SemaphoreSlim SearchSemaphore;
+        private AdaptiveConcurrencyController SearchConcurrencyController;
+        private readonly object SearchConcurrencySync = new object();
+        private int CurrentSearchLimit;
+        private int PersistentCacheHits = 0;
+        private int InMemoryCacheHits = 0;
+        private int PageFetches = 0;
+        private PageCache PageCache;
+        private AdaptiveConcurrencyController ConcurrencyController;
+        private SemaphoreSlim DynamicSemaphore;
+        private readonly object ConcurrencySync = new object();
+        private int CurrentSemaphoreLimit;
+        private const int SemaphoreUpperBound = 128;
+
+        private readonly HttpClient httpClient;
+        private Task PageCacheInitTask;
+        // Thread-local Random to provide jitter without creating many Sequential Random instances
+        private static readonly ThreadLocal<Random> _rnd = new ThreadLocal<Random>(() => new Random(Guid.NewGuid().GetHashCode()));
+
+        private readonly ConcurrentQueue<long> RecentSearchSamples = new ConcurrentQueue<long>();
+        private const int RecentSamplesWindow = 200;
+
+        private readonly ConcurrentQueue<int> RecentSearchStatusCodes = new ConcurrentQueue<int>();
+        private const int RecentStatusWindow = 200;
+
+        private DateTime SearchBackoffUntil = DateTime.MinValue;
+        private int SearchBackoffLimit = 0;
+        private readonly object BackoffSync = new object();
+
+        private string CachedAuthToken = null;
+        private DateTime CachedAuthTokenExpiry = DateTime.MinValue;
+        private readonly object AuthTokenSync = new object();
+
+        private CancellationTokenSource monitorCts;
+        private Task monitorTask;
+        private readonly object monitorSync = new object();
+        private bool _disposed = false;
+
+
+        #region Urls
+
+        private static string UrlBase => "https://howlongtobeat.com";
+
+        private static string UrlLogin => UrlBase + "/login";
+        private static string UrlLogOut => UrlBase + "/login?t=out";
+        private static string UrlSearchWeb => UrlBase + "/?q={0}";
+
+        private static string UrlUser => UrlBase + "/api/user";
+        private static string UrlUserStats => UrlUser + "?n={0}&s=stats";
+        private static string UrlUserStatsMore => UrlBase + "/user_stats_more";
+        private static string UrlUserStatsGamesList => UrlUser + "/{0}/stats";
+        private static string UrlUserGamesList => UrlUser + "/{0}/games/list";
+        private static string UrlUserStatsGameDetails => UrlBase + "/user_games_detail";
+
+        private static string UrlPostData => UrlBase + "/api/submit";
+        private static string UrlPostDataEdit => UrlBase + "/submit/edit/{0}";
+
+        private static string SearchEndPoint => "/api/locate";
+        private static string UrlSearch => UrlBase + SearchEndPoint;
+
+        private static string UrlGameImg => UrlBase + "/games/{0}";
+
+        private static string UrlGame => UrlBase + "/game?id={0}";
+
+        private static string UrlExportAll => UrlBase + "/user_export?all=1";
+
+        #endregion
+
+
+        private bool? _isConnected = null;
+        /// <summary>
+        /// Indicates if the user is currently connected (logged in).
+        /// </summary>
+        public bool? IsConnected { get => _isConnected; set => SetValue(ref _isConnected, value); }
+
+        /// <summary>
+        /// The username of the currently logged-in user.
+        /// </summary>
+        public string UserLogin { get; set; } = string.Empty;
+        /// <summary>
+        /// The user ID of the currently logged-in user.
+        /// </summary>
+        public int UserId { get; set; } = 0;
+
+        private bool IsFirst = true;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HowLongToBeatApi"/> class.
+        /// </summary>
+        public HowLongToBeatApi()
+        {
+            try
+            {
+                var handler = new HttpClientHandler();
+                var prop = handler.GetType().GetProperty("MaxConnectionsPerServer");
+                if (prop != null && prop.CanWrite)
+                {
+                    prop.SetValue(handler, Math.Max(4, MaxParallelGameDataDownloads));
+                }
+                else
+                {
+                    Logger.Warn("HLTB: MaxConnectionsPerServer not available; using default connection limits");
+                }
+
+                httpClient = new HttpClient(handler)
+                {
+                    Timeout = System.Threading.Timeout.InfiniteTimeSpan
+                };
+                httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent);
+                try { httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Referer", UrlBase); } catch { }
+                try { httpClient.DefaultRequestHeaders.Add("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "HLTB: HttpClient init failed");
+                throw;
+            }
+
+            // Create default alias file if missing (non-fatal)
+            try
+            {
+                GameNameAliases.EnsureAliasFileExists(PluginDatabase?.Plugin?.GetPluginUserDataPath());
+            }
+            catch { }
+
+            // Cache HtmlAgilityPack availability once to avoid reflection on every request.
+            Type hapType = null;
+            try
+            {
+                hapType = Type.GetType("HtmlAgilityPack.HtmlDocument, HtmlAgilityPack");
+            }
+            catch { }
+            HapDocType = hapType;
+            HapAvailable = HapDocType != null;
+
+            UserLogin = PluginDatabase.PluginSettings.Settings.UserLogin;
+
+            CookiesDomains = new List<string>
+            {
+                ".howlongtobeat.com",
+                "howlongtobeat.com",
+                "www.howlongtobeat.com",
+                ".www.howlongtobeat.com"
+            };
+            string pathData = PluginDatabase.Paths.PluginUserDataPath;
+            FileCookies = Path.Combine(pathData, CommonPlayniteShared.Common.Paths.GetSafePathName($"HowLongToBeat.dat"));
+            CookiesTools = new CookiesTools(
+                PluginDatabase.PluginName,
+                "HowLongToBeat",
+                FileCookies,
+                CookiesDomains
+            );
+
+            try
+            {
+                var exists = File.Exists(FileCookies);
+                long size = 0;
+                if (exists)
+                {
+                    try { size = new FileInfo(FileCookies).Length; } catch { }
+                }
+
+                Logger.Info($"HLTB Auth: cookie file='{FileCookies}' exists={exists} size={size}");
+                if (exists)
+                {
+                    var stored = CookiesTools.GetStoredCookies();
+                    LogCookieSummary("startup stored", stored);
+
+                    // Non-critical: validate cookies on startup to help diagnose "logged out after restart".
+                    FireAndForget(Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await Task.Delay(2000).ConfigureAwait(false);
+                            bool ok = await GetIsUserLoggedInAsync().ConfigureAwait(false);
+                            Logger.Info($"HLTB Auth: startup cookie check ok={ok} userId={UserId}");
+                        }
+                        catch (Exception ex)
+                        {
+                            try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+                        }
+                    }), "startup cookie check");
+                }
+            }
+            catch { }
+
+            try
+            {
+                PageCacheInitTask = Task.Run(() =>
+                {
+                    PageCache localPc = null;
+                    try
+                    {
+                        localPc = new PageCache(PluginDatabase.Plugin.GetPluginUserDataPath());
+                        if (!_disposed)
+                        {
+                            PageCache = localPc;
+                            localPc = null;
+                        }
+                        else
+                        {
+                            try { (localPc as IDisposable)?.Dispose(); } catch { }
+                            localPc = null;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Common.LogError(ex, false);
+                        try { Logger.Warn("HLTB: PageCache init failed; proceeding without persistent cache"); } catch { }
+                        if (localPc != null)
+                        {
+                            try { (localPc as IDisposable)?.Dispose(); } catch { }
+                            localPc = null;
+                        }
+                    }
+                });
+
+                // Observe any exceptions from the init task so they don't go unobserved
+                PageCacheInitTask.ContinueWith(t =>
+                {
+                    try
+                    {
+                        if (t.IsFaulted && t.Exception != null)
+                        {
+                            Common.LogError(t.Exception, false);
+                        }
+                    }
+                    catch { }
+                }, TaskContinuationOptions.OnlyOnFaulted);
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false);
+            }
+
+            // Configure bounded in-memory caches to avoid unbounded growth during large imports
+            // Sizes are conservative defaults; can be tuned via settings later.
+            GamePageCache = new LruCache<string, string>(capacity: 2000, ttl: TimeSpan.FromHours(6));
+            SearchCache = new LruCache<string, SearchResult>(capacity: 2000, ttl: TimeSpan.FromHours(6));
+
+            try
+            {
+                ConcurrencyController = new AdaptiveConcurrencyController(MaxParallelGameDataDownloads, 4, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
+                DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads, SemaphoreUpperBound);
+                CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
+                try
+                {
+                    SearchConcurrencyController = new AdaptiveConcurrencyController(MaxParallelSearches, 2, SemaphoreUpperBound, TimeSpan.FromSeconds(2));
+                    CurrentSearchLimit = MaxParallelSearches;
+                    SearchSemaphore = new SemaphoreSlim(MaxParallelSearches, SemaphoreUpperBound);
+                }
+                catch (Exception ex)
+                {
+                    try { Logger.Warn(ex, "HLTB: Search concurrency controller init failed; using basic semaphore"); } catch { }
+                    SearchSemaphore = new SemaphoreSlim(MaxParallelSearches);
+                    CurrentSearchLimit = MaxParallelSearches;
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false);
+                try { Logger.Warn("HLTB: Adaptive concurrency init failed; using basic semaphore defaults"); } catch { }
+                DynamicSemaphore = new SemaphoreSlim(MaxParallelGameDataDownloads);
+                CurrentSemaphoreLimit = MaxParallelGameDataDownloads;
+            }
+
+        }
+
+        public void StopMonitoring()
+        {
+            try
+            {
+                var task = monitorTask;
+                var cts = monitorCts;
+
+                try { cts?.Cancel(); } catch { }
+
+                if (task != null)
+                {
+                    try { task.Wait(5000); } catch { }
+                }
+
+                try { cts?.Dispose(); } catch { }
+                monitorCts = null;
+                monitorTask = null;
+            }
+            catch { }
+        }
+
+        private void EnsureMonitoringStarted()
+        {
+            if (_disposed) return;
+            lock (monitorSync)
+            {
+                if (monitorTask != null && !monitorTask.IsCompleted && monitorCts != null && !monitorCts.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                try { monitorCts?.Dispose(); } catch { }
+                monitorCts = new CancellationTokenSource();
+                try
+                {
+                    monitorTask = Task.Run(async () =>
+                    {
+                        var token = monitorCts.Token;
+                        try
+                        {
+                            while (!token.IsCancellationRequested)
+                            {
+                                try
+                                {
+                                    if (token.IsCancellationRequested) break;
+                                    await Task.Delay(TimeSpan.FromSeconds(10), token).ConfigureAwait(false);
+                                }
+                                catch (OperationCanceledException)
+                                {
+                                    break;
+                                }
+                                catch (Exception) { }
+                                try
+                                {
+                                    int searchTarget;
+                                    bool searchForced = false;
+                                    try
+                                    {
+                                        int fixedTarget = MaxParallelSearches;
+                                        lock (BackoffSync)
+                                        {
+                                            if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
+                                            {
+                                                searchTarget = Math.Min(fixedTarget, SearchBackoffLimit);
+                                            }
+                                            else
+                                            {
+                                                searchTarget = fixedTarget;
+                                            }
+                                        }
+                                        searchForced = true;
+                                    }
+                                    catch
+                                    {
+                                        searchTarget = SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
+                                    }
+
+                                    int searchAvailable = 0;
+                                    int searchInFlight = 0;
+                                    int gameTarget = 0;
+                                    int gameAvailable = 0;
+                                    int gameInFlight = 0;
+                                    try
+                                    {
+                                        searchAvailable = SearchSemaphore?.CurrentCount ?? 0;
+                                        searchInFlight = Math.Max(0, searchTarget - searchAvailable);
+
+                                        gameTarget = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+                                        gameAvailable = DynamicSemaphore?.CurrentCount ?? 0;
+                                        gameInFlight = Math.Max(0, gameTarget - gameAvailable);
+                                    }
+                                    catch (ObjectDisposedException) { break; }
+                                    catch (InvalidOperationException) { break; }
+
+                                    var samples = RecentSearchSamples.ToArray();
+                                    double avg = samples.Length > 0 ? samples.Average() : 0;
+                                    double median = 0;
+                                    double p90 = 0;
+                                    if (samples.Length > 0)
+                                    {
+                                        var ordered = samples.OrderBy(x => x).ToArray();
+                                        median = ordered[ordered.Length / 2];
+                                        p90 = ordered[Math.Max(0, (int)Math.Floor(ordered.Length * 0.9) - 1)];
+                                    }
+
+                                    LogDebugVerbose($"HLTB Summary: searchTarget={searchTarget} searchInFlight={searchInFlight} gameTarget={gameTarget} gameInFlight={gameInFlight} avgSearchMs={Math.Round(avg, 1)} medianSearchMs={Math.Round(median, 1)} p90SearchMs={Math.Round(p90, 1)} persistentCacheHits={PersistentCacheHits} inMemoryCacheHits={InMemoryCacheHits} pageFetches={PageFetches} forced={searchForced}");
+                                }
+                                catch (Exception ex)
+                                {
+                                    try { Logger.Error(ex, "HLTB monitor loop error"); } catch { }
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            try { Logger.Error(ex, "HLTB monitor task terminated unexpectedly"); } catch { }
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    try { Logger.Error(ex, "Failed to start HLTB monitor task"); } catch { }
+                }
+            }
+        }
+
+        ~HowLongToBeatApi()
+        {
+            try { Dispose(false); } catch { }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            try { GC.SuppressFinalize(this); } catch { }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            _disposed = true;
+
+            if (disposing)
+            {
+                try
+                {
+                    // Use StopMonitoring as single shutdown path; it will cancel and cleanup without blocking.
+                    try { StopMonitoring(); } catch { }
+                }
+                catch { }
+                finally
+                {
+                    monitorTask = null;
+                    monitorCts = null;
+                }
+
+                try { ConcurrencyController?.Dispose(); } catch { }
+                ConcurrencyController = null;
+                try { SearchConcurrencyController?.Dispose(); } catch { }
+                SearchConcurrencyController = null;
+
+                try { DynamicSemaphore?.Dispose(); } catch { }
+                DynamicSemaphore = null;
+                try { SearchSemaphore?.Dispose(); } catch { }
+                SearchSemaphore = null;
+
+                try { httpClient?.Dispose(); } catch { }
+
+                // Dispose page cache if it implements IDisposable
+                try
+                {
+                    if (PageCache is IDisposable disposableCache)
+                    {
+                        try { disposableCache.Dispose(); } catch { }
+                    }
+                }
+                catch { }
+                PageCache = null;
+            }
+        }
+
+
+        /// <summary>
+        /// Retrieves game data from HowLongToBeat by game ID.
+        /// </summary>
+        /// <param name="id">The game ID.</param>
+        /// <returns>Returns <see cref="HltbData"/> with game times, or null if not found.</returns>
+        private async Task<HltbData> GetGameData(string id, CancellationToken cancellationToken = default)
+        {
+            try { EnsureMonitoringStarted(); } catch { }
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var init = PageCacheInitTask;
+                if (init != null && PageCache == null)
+                {
+                    await Task.WhenAny(init, Task.Delay(500)).ConfigureAwait(false);
+                }
+            }
+            catch { }
+            DateTime startTime = DateTime.UtcNow;
+            LogDebugVerbose($"GetGameData START id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} time={startTime:HH:mm:ss.fff}");
+
+            try
+            {
+                string jsonData = null;
+                try
+                {
+                    if (PageCache != null && PageCache.TryGetJson(id, out string cachedJson))
+                    {
+                        jsonData = cachedJson;
+                        try { System.Threading.Interlocked.Increment(ref PersistentCacheHits); } catch { }
+                        LogDebugVerbose($"GetGameData id={id} - persistent cache hit");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                }
+
+                int attempts = 0;
+                if (string.IsNullOrEmpty(jsonData))
+                {
+                    string response = string.Empty;
+                    int maxAttempts = 3;
+                    int baseDelayMs = 300;
+                    var rnd = _rnd.Value;
+                    while (attempts < maxAttempts)
+                    {
+                        attempts++;
+                        try
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+                            if (GamePageCache.TryGetValue(id, out string cached))
+                            {
+                                response = cached;
+                                try { System.Threading.Interlocked.Increment(ref InMemoryCacheHits); } catch { }
+                                LogDebugVerbose($"GetGameData id={id} - in-memory cache hit");
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    using (var httpResp = await httpClient.GetAsync(string.Format(UrlGame, id), cancellationToken).ConfigureAwait(false))
+                                    {
+                                        if (!httpResp.IsSuccessStatusCode)
+                                        {
+                                            var code = (int)httpResp.StatusCode;
+                                            LogDebugVerbose($"GetGameData id={id} - HTTP {code} fetching page");
+                                            response = string.Empty;
+                                        }
+                                        else
+                                        {
+                                            response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                                        }
+                                    }
+                                }
+                                catch (HttpRequestException hre)
+                                {
+                                    Common.LogError(hre, false, false, PluginDatabase.PluginName);
+                                    response = string.Empty;
+                                }
+                            }
+
+                            if (!response.IsNullOrEmpty())
+                            {
+                                string maybeJson = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
+                                if (!maybeJson.IsNullOrEmpty())
+                                {
+                                    GamePageCache.TryAdd(id, response);
+                                    try
+                                    {
+                                        PageCache?.Set(id, maybeJson);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                                    }
+                                    try { System.Threading.Interlocked.Increment(ref PageFetches); } catch { }
+                                    jsonData = maybeJson;
+                                    break;
+                                }
+                                else
+                                {
+                                    Common.LogDebug(true, $"GetGameData id={id} - extracted JSON was empty or incomplete (attempt={attempts})");
+                                    response = string.Empty;
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                        }
+
+                        if (attempts < maxAttempts)
+                        {
+                            var jitter = rnd.Next(0, 200);
+                            var delay = baseDelayMs * attempts + jitter;
+                            LogDebugVerbose($"GetGameData id={id} - retry {attempts} after {delay}ms");
+                            try { await Task.Delay(delay, cancellationToken); } catch (OperationCanceledException) { throw; }
+                        }
+                    }
+                }
+                if (string.IsNullOrEmpty(jsonData))
+                {
+                    Common.LogDebug(true, $"GetGameData id={id} - no JSON extracted after {attempts} attempts");
+                    Logger.Warn($"No GameData find with {id}");
+                    double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                    try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
+                    LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
+                    return null;
+                }
+
+                _ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
+                if (parseEx != null)
+                {
+                    Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
+                }
+
+                GameData gameData = next_data?.Props?.PageProps?.Game?.Data?.Game != null
+                    ? next_data.Props.PageProps.Game.Data.Game.FirstOrDefault()
+                    : null;
+
+                if (gameData != null)
+                {
+                    HltbData hltbData = new HltbData
+                    {
+                        MainStoryClassic = gameData.CompMain,
+                        MainExtraClassic = gameData.CompPlus,
+                        CompletionistClassic = gameData.Comp100,
+                        SoloClassic = gameData.CompAll,
+                        CoOpClassic = gameData.InvestedCo,
+                        VsClassic = gameData.InvestedMp,
+
+                        MainStoryMedian = gameData.CompMainMed,
+                        MainExtraMedian = gameData.CompPlusMed,
+                        CompletionistMedian = gameData.Comp100Med,
+                        SoloMedian = gameData.CompAllMed,
+                        CoOpMedian = gameData.InvestedCoMed,
+                        VsMedian = gameData.InvestedMpMed,
+
+                        MainStoryAverage = gameData.CompMainAvg,
+                        MainExtraAverage = gameData.CompPlusAvg,
+                        CompletionistAverage = gameData.Comp100Avg,
+                        SoloAverage = gameData.CompAllAvg,
+                        CoOpAverage = gameData.InvestedCoAvg,
+                        VsAverage = gameData.InvestedMpAvg,
+
+                        MainStoryRushed = gameData.CompMainL,
+                        MainExtraRushed = gameData.CompPlusL,
+                        CompletionistRushed = gameData.Comp100L,
+                        SoloRushed = gameData.CompAllL,
+                        CoOpRushed = gameData.InvestedCoL,
+                        VsRushed = gameData.InvestedMpL,
+
+                        MainStoryLeisure = gameData.CompMainH,
+                        MainExtraLeisure = gameData.CompPlusH,
+                        CompletionistLeisure = gameData.Comp100H,
+                        SoloLeisure = gameData.CompAllH,
+                        CoOpLeisure = gameData.InvestedCoH,
+                        VsLeisure = gameData.InvestedMpH
+                    };
+
+                    double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                    try { ConcurrencyController?.ReportSample(elapsed, true); } catch { }
+                    LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
+                    return hltbData;
+                }
+                else
+                {
+                    Logger.Warn($"No GameData find with {id}");
+                    double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+                    try { ConcurrencyController?.ReportSample(elapsed, false); } catch { }
+                    LogDebugVerbose($"GetGameData DONE id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={elapsed}ms");
+                    return null;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                Logger.Info($"GetGameData ERROR id={id} task={Task.CurrentId} thread={Thread.CurrentThread.ManagedThreadId} elapsed={(DateTime.UtcNow - startTime).TotalMilliseconds}ms");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Updates the HLTB data for a user game entry.
+        /// </summary>
+        /// <param name="hltbDataUser">The user game data to update.</param>
+        /// <returns>Returns the updated <see cref="HltbDataUser"/>.</returns>
+        public async Task<HltbDataUser> UpdateGameData(HltbDataUser hltbDataUser)
+        {
+            try
+            {
+                HltbData hltbData = await GetGameData(hltbDataUser.Id);
+                hltbDataUser.GameHltbData = hltbData ?? hltbDataUser.GameHltbData;
+                return hltbDataUser;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                return null;
+            }
+        }
+
+
+        #region Search
+
+        /// <summary>
+        /// Retrieves the search URL from the website scripts.
+        /// </summary>
+        /// <returns>The search endpoint URL.</returns>
+        private async Task<string> GetSearchUrl()
+        {
+            if (!SearchUrl.IsNullOrEmpty())
+            {
+                return SearchUrl;
+            }
+
+            try
+            {
+                string url = UrlBase;
+
+                string response = null;
+                using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
+                {
+                    try
+                    {
+                        using (var httpResp = await httpClient.GetAsync(url, cts.Token).ConfigureAwait(false))
+                        {
+                            if (!httpResp.IsSuccessStatusCode)
+                            {
+                                try { Logger.Warn($"HTTP {(int)httpResp.StatusCode} downloading {url}"); } catch { }
+                                return "/api/s";
+                            }
+
+                            response = await httpResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        }
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {url}"); } catch { }
+                        return "/api/s";
+                    }
+                    catch (Exception ex)
+                    {
+                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                        return "/api/s";
+                    }
+                }
+
+                // Try to extract script URLs via optional HtmlAgilityPack helper (reflection). Fall back to regex if unavailable.
+                List<string> scriptUrls = ExtractScriptUrlsWithHap(response) ?? new List<string>();
+                if (scriptUrls.Count == 0)
+                {
+
+                    var matches = MyRegex().Matches(response);
+                    foreach (Match match in matches)
+                    {
+                        scriptUrls.Add(match.Groups[1].Value);
+                    }
+                }
+
+                var ordered = scriptUrls.Where(s => s.Contains("_app-")).Concat(scriptUrls).Where(s => !string.IsNullOrEmpty(s)).Distinct();
+                foreach (string sUrl in ordered)
+                {
+                    string scriptUrl = sUrl;
+                    if (!scriptUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                    {
+                        scriptUrl = UrlBase + scriptUrl;
+                    }
+
+                    string scriptContent = null;
+                    using (var ctsScript = new CancellationTokenSource(ScriptDownloadTimeoutMs))
+                    {
+                        try
+                        {
+                            using (var scriptResp = await httpClient.GetAsync(scriptUrl, ctsScript.Token).ConfigureAwait(false))
+                            {
+                                if (!scriptResp.IsSuccessStatusCode)
+                                {
+                                    try { Logger.Warn($"HTTP {(int)scriptResp.StatusCode} downloading {scriptUrl}"); } catch { }
+                                    continue;
+                                }
+
+                                scriptContent = await scriptResp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            }
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading {scriptUrl}"); } catch { }
+                            continue;
+                        }
+                        catch (Exception ex)
+                        {
+                            Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                            continue;
+                        }
+                    }
+
+                    string pattern = "fetch\\s*\\(\\s*[\"']\\/api\\/([a-zA-Z0-9_\\/]+)[^\"']*[\"']\\s*,\\s*\\{[^}]*method:\\s*[\"']POST[\"'][^}]*\\}";
+                    var searchMatch = Regex.Match(scriptContent, pattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+                    if (searchMatch.Success)
+                    {
+                        string suffix = searchMatch.Groups[1].Value;
+                        if (suffix.Contains("/"))
+                        {
+                            suffix = suffix.Split('/')[0];
+                        }
+
+                        if (suffix != "find")
+                        {
+                            lock (SearchUrlLock)
+                            {
+                                if (SearchUrl.IsNullOrEmpty())
+                                {
+                                    SearchUrl = "/api/" + suffix;
+                                }
+                            }
+                            return SearchUrl;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+            }
+
+            return "/api/s";
+        }
 
 		/// <summary>
 		/// Retrieves the authentication token.
 		/// </summary>
+		/// <param name="apiEndpoint">API Endpoint for search</param>
 		/// <returns>The auth token.</returns>
-		private async Task<Dictionary<string, string>> GetAuthToken(string apiEndpoint)
-		{
-			try
-			{
-				// Double-checked locking: quick snapshot first to avoid locking in common case
-				var snapshotToken = CachedAuthToken;
-				var snapshotExpiry = CachedAuthTokenExpiry;
-				if (!string.IsNullOrEmpty(snapshotToken) && DateTime.UtcNow < snapshotExpiry)
-				{
-					//return snapshotToken;
-				}
-
-				// Re-check under lock to avoid race with a concurrent writer
-				lock (AuthTokenSync)
-				{
-					if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
-					{
-						//return CachedAuthToken;
-					}
-				}
-
-				List<HttpHeader> headers = new List<HttpHeader>
-				{
-					new HttpHeader { Key = "Referer", Value = UrlBase }
-				};
-				string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
-				string response = null;
-				try
-				{
-					using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
-					using (var request = new HttpRequestMessage(HttpMethod.Get, url))
-					{
-						try { request.Headers.Add("Referer", UrlBase); } catch { }
-
-						using (var resp = await httpClient.SendAsync(request, cts.Token).ConfigureAwait(false))
-						{
-							if (!resp.IsSuccessStatusCode)
-							{
-								try { Logger.Warn($"HTTP {(int)resp.StatusCode} downloading auth init {url}"); } catch { }
-								return null;
-							}
-
-							response = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-						}
-					}
-				}
-				catch (TaskCanceledException)
-				{
-					try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading auth init {url}"); } catch { }
-					return null;
-				}
-				catch (Exception ex)
-				{
-					Common.LogError(ex, false, true, PluginDatabase.PluginName);
-					return null;
-				}
-
-				var data = Serialization.FromJson<Dictionary<string, string>>(response);
-				if (data != null && data.TryGetValue("token", out string token))
-				{
-					lock (AuthTokenSync)
-					{
-						// Final re-check before writing to shared fields
-						if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
-						{
-							//return CachedAuthToken;
-						}
-						CachedAuthToken = token;
-						CachedAuthTokenExpiry = DateTime.UtcNow.AddSeconds(90);
-					}
-					if (data.TryGetValue("hpKey", out string hpKey) && data.TryGetValue("hpVal", out string hpVal))
-					{
-						var headerParts = new Dictionary<string, string>
-						{
-							{ "Token", token },
-							{ "Hpkey", hpKey },
-							{ "Hpval", hpVal }
-						};
-
-						return headerParts;
-					}
-
-
-					//return token;
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-			}
-			return null;
-		}
-
-
-		/// <summary>
-		/// Searches for games on HowLongToBeat by name and platform.
-		/// </summary>
-		/// <param name="name">Game name to search for.</param>
-		/// <param name="platform">Optional platform filter.</param>
-		/// <returns>Returns a list of <see cref="HltbDataUser"/> matching the search.</returns>
-		private async Task<List<HltbDataUser>> Search(string name, string platform = "")
-		{
-			try
-			{
-				SearchResult searchResult = await ApiSearch(name, platform);
-
-				List<HltbDataUser> search = searchResult?.Data?.Select(x =>
-					new HltbDataUser
-					{
-						Name = x.GameName,
-						Id = x.GameId.ToString(),
-						UrlImg = string.Format(UrlGameImg, x.GameImage),
-						Url = string.Format(UrlGame, x.GameId),
-						Platform = x.ProfilePlatform,
-						GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
-						GameHltbData = new HltbData
-						{
-							GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
-							MainStoryClassic = x.CompMain,
-							MainExtraClassic = x.CompPlus,
-							CompletionistClassic = x.Comp100,
-							SoloClassic = x.CompAll,
-							CoOpClassic = x.InvestedCo,
-							VsClassic = x.InvestedMp
-						},
-						NeedsDetails = !((x.CompMain > 0) || (x.CompAll > 0) || (x.CompPlus > 0) || (x.Comp100 > 0))
-					}
-				)?.ToList() ?? new List<HltbDataUser>();
-
-				if (search.Count != 0)
-				{
-					try
-					{
-						int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-						await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "Search");
-					}
-					catch { }
-
-					var tasks = search.Select(async x =>
-					{
-						bool acquiredGameSemaphore = false;
-						try
-						{
-							try
-							{
-								try
-								{
-									int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-									int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
-									int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
-									LogDebugVerbose($"Search: waiting semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
-								}
-								catch { }
-								var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
-								if (!acquired)
-								{
-									Logger.Warn($"Search: timeout waiting for game data semaphore for id={x.Id}");
-									return;
-								}
-								acquiredGameSemaphore = true;
-								try
-								{
-									int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-									int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
-									int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
-									LogDebugVerbose($"Search: acquired semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
-								}
-								catch { }
-							}
-							catch (Exception ex)
-							{
-								Common.LogError(ex, false, false, PluginDatabase.PluginName);
-							}
-							try
-							{
-								try
-								{
-									bool hasCoreTimes = (x.GameHltbData != null) && (
-										(x.GameHltbData.MainStoryClassic > 0) ||
-										(x.GameHltbData.MainStoryAverage > 0) ||
-										(x.GameHltbData.MainStoryMedian > 0)
-									);
-
-									if (hasCoreTimes)
-									{
-										LogDebugVerbose($"Search: skipping GetGameData for id={x.Id} (search result has times)");
-										x.NeedsDetails = false;
-									}
-									else
-									{
-										using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
-										{
-											try
-											{
-												x.GameHltbData = await GetGameData(x.Id, ctsGame.Token);
-												x.NeedsDetails = false;
-											}
-											catch (OperationCanceledException)
-											{
-												Logger.Warn($"Timeout {GameDataDownloadTimeoutMs}ms getting game data for {x.Id}");
-												x.GameHltbData = null;
-											}
-										}
-									}
-								}
-								catch (Exception ex)
-								{
-									Common.LogError(ex, false, false, PluginDatabase.PluginName);
-									x.GameHltbData = null;
-								}
-							}
-							finally
-							{
-								if (acquiredGameSemaphore)
-								{
-									try
-									{
-										DynamicSemaphore.Release();
-									}
-									catch { }
-								}
-								LogDebugVerbose($"Search: released semaphore for id={x.Id}");
-							}
-						}
-						catch (Exception ex)
-						{
-							Common.LogError(ex, false, false, PluginDatabase.PluginName);
-						}
-					}).ToArray();
-
-					await Task.WhenAll(tasks);
-					try
-					{
-						LogDebugVerbose($"Search summary: persistentCacheHits={PersistentCacheHits}, inMemoryHits={InMemoryCacheHits}, pageFetches={PageFetches}");
-					}
-					catch { }
-				}
-				return search;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				return new List<HltbDataUser>();
-			}
-		}
-
-		/// <summary>
-		/// Performs two search methods (normalized and original name) and merges results.
-		/// </summary>
-		/// <param name="name">Game name to search for.</param>
-		/// <param name="platform">Optional platform filter.</param>
-		/// <returns>Returns a list of <see cref="HltbSearch"/> with match percentages.</returns>
-		public async Task<List<HltbSearch>> SearchTwoMethod(string name, string platform = "", bool includeExtendedTimes = false)
-		{
-			// Apply manual aliases (exact normalized match) to support paired releases (e.g. Pokemon versions).
-			try
-			{
-				var settings = PluginDatabase?.PluginSettings?.Settings;
-				var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
-				var aliased = GameNameAliases.ApplyAlias(name, settings, userDataPath);
-				if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(name))
-				{
-					LogDebugVerbose($"HLTB aliases: '{SafeStr(name)}' -> '{SafeStr(aliased)}'");
-					name = aliased;
-				}
-			}
-			catch { }
-
-			string normalized = PlayniteTools.NormalizeGameName(name, true, true);
-
-			List<HltbDataUser> dataSearch = null;
-			List<HltbDataUser> dataSearchNormalized = null;
-
-			try
-			{
-				if (!string.IsNullOrEmpty(normalized) && !normalized.Equals(name, StringComparison.Ordinal))
-				{
-					var t1 = Search(name, platform);
-					var t2 = Search(normalized, platform);
-					await Task.WhenAll(t1, t2).ConfigureAwait(false);
-					dataSearch = t1.Result ?? new List<HltbDataUser>();
-					dataSearchNormalized = t2.Result ?? new List<HltbDataUser>();
-				}
-				else
-				{
-					dataSearch = await Search(name, platform);
-					dataSearchNormalized = new List<HltbDataUser>();
-				}
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-				dataSearch = dataSearch ?? new List<HltbDataUser>();
-				dataSearchNormalized = dataSearchNormalized ?? new List<HltbDataUser>();
-			}
-
-			var dataSearchFinal = new List<HltbDataUser>();
-			if (dataSearch != null) dataSearchFinal.AddRange(dataSearch);
-			if (dataSearchNormalized != null) dataSearchFinal.AddRange(dataSearchNormalized);
-
-			dataSearchFinal = dataSearchFinal.GroupBy(x => x.Id).Select(x => x.First()).ToList();
-
-			string searchNameLower = (name ?? string.Empty).ToLower();
-			var results = dataSearchFinal
-				.Where(x => x != null)
-				.Select(x => new HltbSearch
-				{
-					MatchPercent = Fuzz.Ratio(searchNameLower, (x.Name ?? string.Empty).ToLower()),
-					Data = x
-				})
-				.OrderByDescending(x => x.MatchPercent)
-				.ToList();
-
-			if (includeExtendedTimes)
-			{
-				try
-				{
-					const int maxDetails = 20;
-					var targets = results
-						.Select(r => r?.Data)
-						.Where(x => x != null && !string.IsNullOrEmpty(x.Id))
-						.Take(maxDetails)
-						.ToList();
-
-					if (targets.Count > 0)
-					{
-						try
-						{
-							int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
-							await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "SearchTwoMethod+Details");
-						}
-						catch { }
-
-						var tasks = targets.Select(async x =>
-						{
-							bool acquiredGameSemaphore = false;
-							try
-							{
-								var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
-								if (!acquired)
-								{
-									return;
-								}
-								acquiredGameSemaphore = true;
-
-								using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
-								{
-									try
-									{
-										var details = await GetGameData(x.Id, ctsGame.Token);
-										if (details != null)
-										{
-											x.GameHltbData = details;
-											x.NeedsDetails = false;
-										}
-									}
-									catch (OperationCanceledException)
-									{
-										// Ignore timeout; keep basic search data
-									}
-									catch
-									{
-										// Ignore; keep basic search data
-									}
-								}
-							}
-							finally
-							{
-								if (acquiredGameSemaphore)
-								{
-									try { DynamicSemaphore.Release(); } catch { }
-								}
-							}
-						}).ToArray();
-
-						await Task.WhenAll(tasks).ConfigureAwait(false);
-					}
-				}
-				catch
-				{
-					// Best-effort enrichment; never fail the whole search.
-				}
-			}
-
-			return results;
-		}
-
-		/// <summary>
-		/// Performs an API search for games.
-		/// </summary>
-		/// <param name="name">Game name to search for.</param>
-		/// <param name="platform">Optional platform filter.</param>
-		/// <returns>Returns a <see cref="SearchResult"/> object.</returns>
-		private async Task<SearchResult> ApiSearch(string name, string platform = "")
-		{
-			try { EnsureMonitoringStarted(); } catch { }
-			int GetSearchTarget()
-			{
-				try
-				{
-					int baseTarget = MaxParallelSearches;
-					lock (BackoffSync)
-					{
-						if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
-						{
-							return Math.Min(baseTarget, SearchBackoffLimit);
-						}
-					}
-					return baseTarget;
-				}
-				catch
-				{
-					return SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
-				}
-			}
-
-			try
-			{
-				string cacheKey = (name ?? string.Empty) + "|" + (platform ?? string.Empty);
-				if (SearchCache.TryGetValue(cacheKey, out SearchResult cachedResult))
-				{
-					try { LogDebugVerbose($"ApiSearch cache hit for '{name}' platform='" + platform + "'"); } catch { }
-					return cachedResult;
-				}
-
-				List<HttpHeader> httpHeaders = new List<HttpHeader>
-				{
-					new HttpHeader { Key = "User-Agent", Value = Web.UserAgent },
-					new HttpHeader { Key = "Origin", Value = UrlBase },
-					new HttpHeader { Key = "Referer", Value = UrlBase }
-				};
-
-				SearchParam searchParam = new SearchParam
-				{
-					SearchTerms = name.Split(' ').ToList(),
-					SearchOptions = new SearchOptions { Games = new Games { Platform = platform } }
-				};
-
-				SearchResult searchResult = null;
-				string baseJson = Serialization.ToJson(searchParam);
-				var dict = Serialization.FromJson<Dictionary<string, object>>(baseJson);
-				string searchUrl = await GetSearchUrl();
-				bool tokenReused = !string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry;
-				Dictionary<string, string> headerParts = await GetAuthToken(searchUrl);
-				string token = headerParts["Token"];
-				string hpKey = headerParts["Hpkey"];
-				string hpVal = headerParts["Hpval"];
-				if (!token.IsNullOrEmpty())
-				{
-					httpHeaders.Add(new HttpHeader { Key = "x-auth-token", Value = token });
-				}
-
-				if (!hpKey.IsNullOrEmpty() && !hpVal.IsNullOrEmpty())
-				{
-					httpHeaders.Add(new HttpHeader { Key = "x-hp-key", Value = hpKey });
-					httpHeaders.Add(new HttpHeader { Key = "x-hp-val", Value = hpVal });
-					dict[hpKey] = hpVal;
-				}
-
-				string serializedBody = Serialization.ToJson(dict);
-
-				bool acquired = false;
-				try
-				{
-					try
-					{
-						try
-						{
-							int target = GetSearchTarget();
-							await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, target, SearchConcurrencySync, "ApiSearch+Initial");
-						}
-						catch { }
-
-						try
-						{
-							int targetLog = GetSearchTarget();
-							int availableLog = SearchSemaphore?.CurrentCount ?? 0;
-							int inFlightLog = Math.Max(0, targetLog - availableLog);
-							LogDebugVerbose($"ApiSearch: waiting search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
-						}
-						catch { }
-						bool waitOk = true;
-						if (SearchSemaphore != null)
-						{
-							waitOk = await SearchSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
-						}
-						if (!waitOk)
-						{
-							Logger.Warn($"ApiSearch: timeout waiting search semaphore for '{name}'");
-							return null;
-						}
-						acquired = true;
-						try
-						{
-							int targetLog = GetSearchTarget();
-							int availableLog = SearchSemaphore?.CurrentCount ?? 0;
-							int inFlightLog = Math.Max(0, targetLog - availableLog);
-							LogDebugVerbose($"ApiSearch: acquired search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
-						}
-						catch { }
-					}
-					catch (Exception ex)
-					{
-						Common.LogError(ex, false, false, PluginDatabase.PluginName);
-					}
-
-					var sw = Stopwatch.StartNew();
-					// Use local helper to avoid dependency on optional CommonPluginsShared submodule.
-					// Allow the POST to be cancelled/timeout independently of the shared HttpClient timeout by using a bounded CTS.
-					(string body, int status, string retry) postResult;
-					using (var postCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
-					{
-						postResult = await PostJsonWithSharedClientWithStatus(UrlBase + searchUrl, serializedBody, httpHeaders, postCts.Token);
-					}
-					sw.Stop();
-					string json = postResult.body ?? string.Empty;
-					int statusCode = postResult.status;
-					string retryAfterHeader = postResult.retry;
-
-					try
-					{
-						if (statusCode == 429)
-						{
-							int backoffSeconds = 30;
-							if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsedSeconds))
-							{
-								backoffSeconds = Math.Max(1, parsedSeconds);
-							}
-
-							lock (BackoffSync)
-							{
-								int newLimit = Math.Max(1, CurrentSearchLimit / 2);
-								SearchBackoffLimit = newLimit;
-								SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
-							}
-
-							Logger.Warn($"ApiSearch: received 429 for '{name}'. Immediate backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
-						}
-					}
-					catch { }
-
-					try
-					{
-						try
-						{
-							RecentSearchSamples.Enqueue(sw.ElapsedMilliseconds);
-							while (RecentSearchSamples.Count > RecentSamplesWindow)
-							{
-								RecentSearchSamples.TryDequeue(out _);
-							}
-						}
-						catch { }
-
-						try
-						{
-							RecentSearchStatusCodes.Enqueue(statusCode);
-							while (RecentSearchStatusCodes.Count > RecentStatusWindow)
-							{
-								RecentSearchStatusCodes.TryDequeue(out _);
-							}
-						}
-						catch { }
-
-						LogDebugVerbose($"ApiSearch elapsed={sw.ElapsedMilliseconds}ms tokenReused={tokenReused} status={statusCode}");
-					}
-					catch { }
-
-					_ = Serialization.TryFromJson(json, out searchResult);
-
-					try
-					{
-						bool successSample = searchResult != null && searchResult.Data != null && statusCode != 429;
-						SearchConcurrencyController?.ReportSample(sw.ElapsedMilliseconds, successSample);
-					}
-					catch { }
-
-					int postLockPendingConsume = 0;
-					try
-					{
-						var codes = RecentSearchStatusCodes.ToArray();
-						if (codes.Length > 0)
-						{
-							int count429 = codes.Count(c => c == 429);
-							double frac = count429 / (double)codes.Length;
-							if (count429 >= 3 && frac >= 0.05)
-							{
-								lock (BackoffSync)
-								{
-									if (SearchBackoffLimit == 0 || DateTime.UtcNow >= SearchBackoffUntil)
-									{
-										int newLimit = Math.Max(1, CurrentSearchLimit / 2);
-										SearchBackoffLimit = newLimit;
-
-										int backoffSeconds = 30;
-										try
-										{
-											if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsed))
-											{
-												backoffSeconds = Math.Max(1, parsed);
-											}
-										}
-										catch { }
-										SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
-										Logger.Warn($"ApiSearch: detected elevated 429 rate ({count429}/{codes.Length}). Applying temporary search backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
-										try
-										{
-											int currentLimitSnapshot;
-											lock (SearchConcurrencySync)
-											{
-												currentLimitSnapshot = CurrentSearchLimit;
-											}
-											int diff = SearchBackoffLimit - currentLimitSnapshot;
-											if (diff > 0)
-											{
-												try { SearchSemaphore.Release(diff); } catch { }
-												lock (SearchConcurrencySync)
-												{
-													CurrentSearchLimit = SearchBackoffLimit;
-												}
-											}
-											else if (diff < 0)
-											{
-												postLockPendingConsume = -diff;
-											}
-										}
-										catch { }
-									}
-								}
-							}
-						}
-					}
-					catch { }
-
-					try
-					{
-						if (postLockPendingConsume > 0)
-						{
-							int backoffSnapshot;
-							lock (BackoffSync)
-							{
-								backoffSnapshot = SearchBackoffLimit;
-							}
-
-							await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, backoffSnapshot, SearchConcurrencySync, "ApiSearch+PostBackoff");
-						}
-					}
-					catch { }
-
-					try
-					{
-						if (searchResult != null)
-						{
-							SearchCache.TryAdd(cacheKey, searchResult);
-						}
-					}
-					catch { }
-
-					return searchResult;
-				}
-				finally
-				{
-					if (acquired)
-					{
-						try
-						{
-							SearchSemaphore.Release();
-							LogDebugVerbose($"ApiSearch: released search semaphore for '{name}'");
-						}
-						catch { }
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Opens a selection window for the user to choose the correct game data.
-		/// </summary>
-		/// <param name="game">The Playnite game object.</param>
-		/// <param name="data">Optional list of search results.</param>
-		/// <returns>Returns a <see cref="GameHowLongToBeat"/> object if a selection is made, otherwise null.</returns>
-		public GameHowLongToBeat SearchData(Game game, List<HltbDataUser> data = null)
-		{
-			Common.LogDebug(true, $"Search data for {game.Name}");
-			if (API.Instance.ApplicationInfo.Mode == ApplicationMode.Desktop)
-			{
-				HowLongToBeatSelect ViewExtension = null;
-				_ = Application.Current.Dispatcher.BeginInvoke((Action)delegate
-				{
-					ViewExtension = new HowLongToBeatSelect(game, data);
-					Window windowExtension = PlayniteUiHelper.CreateExtensionWindow(ResourceProvider.GetString("LOCSelection") + " - " + game.Name + " - " + (game.Source?.Name ?? "Playnite"), ViewExtension);
-					_ = windowExtension.ShowDialog();
-				}).Wait();
-
-				if (ViewExtension.GameHowLongToBeat?.Items.Count > 0)
-				{
-					return ViewExtension.GameHowLongToBeat;
-				}
-			}
-			return null;
-		}
-
-		public HltbDataUser SearchDataAuto(string gameName, string platform = "")
-		{
-			string traceId = null;
-			try
-			{
-				if (string.IsNullOrEmpty(gameName))
-				{
-					return null;
-				}
-
-				// Apply manual aliases (exact normalized match) early so all subsequent matching uses the aliased title.
-				try
-				{
-					var settings = PluginDatabase?.PluginSettings?.Settings;
-					var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
-					var aliased = GameNameAliases.ApplyAlias(gameName, settings, userDataPath);
-					if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(gameName))
-					{
-						LogDebugVerbose($"HLTB aliases: '{SafeStr(gameName)}' -> '{SafeStr(aliased)}'");
-						gameName = aliased;
-					}
-				}
-				catch { }
-
-				traceId = Guid.NewGuid().ToString("N").Substring(0, 8);
-
-				var hltbSettings = PluginDatabase?.PluginSettings?.Settings;
-
-				if (IsVerboseLoggingEnabled)
-				{
-					try
-					{
-						Logger.Debug($"SearchDataAuto[{traceId}]: start name='{SafeStr(gameName)}' platform='{SafeStr(platform)}' UseMatchValue={hltbSettings?.UseMatchValue} MatchValue={hltbSettings?.MatchValue}");
-					}
-					catch { }
-				}
-
-				List<HltbSearch> results = null;
-				bool gotResults = false;
-				try
-				{
-					// 1) First pass: fast search (no details fetch)
-					gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 15000, Logger);
-					if (!gotResults)
-					{
-						if (IsVerboseLoggingEnabled)
-						{
-							try { Logger.Warn($"SearchDataAuto[{traceId}]: SearchTwoMethod timed out after 15000ms; retrying once"); } catch { }
-						}
-
-						gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 30000, Logger);
-					}
-				}
-				catch (Exception ex)
-				{
-					if (IsVerboseLoggingEnabled)
-					{
-						try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
-					}
-					results = null;
-				}
-
-				if (!gotResults)
-				{
-					if (IsVerboseLoggingEnabled)
-					{
-						try { Logger.Debug($"SearchDataAuto[{traceId}]: no results (timeout)"); } catch { }
-					}
-					return null;
-				}
-
-				if (results == null || results.Count == 0)
-				{
-					if (IsVerboseLoggingEnabled)
-					{
-						try { Logger.Debug($"SearchDataAuto[{traceId}]: no results"); } catch { }
-					}
-					return null;
-				}
-
-				if (IsVerboseLoggingEnabled)
-				{
-					try
-					{
-						Logger.Debug($"SearchDataAuto[{traceId}]: results count={results.Count}");
-						int take = Math.Min(8, results.Count);
-						for (int i = 0; i < take; i++)
-						{
-							var r = results[i];
-							var d = r?.Data;
-							long ttb = 0;
-							bool hasAnyTime = false;
-							try
-							{
-								ttb = d?.GameHltbData?.TimeToBeat ?? 0;
-								hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
-							}
-							catch { }
-
-							Logger.Debug($"SearchDataAuto[{traceId}]: candidate[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
-						}
-					}
-					catch { }
-				}
-
-				try
-				{
-					var nQuery = PlayniteTools.NormalizeGameName(gameName ?? string.Empty, true, true);
-					if (!string.IsNullOrEmpty(nQuery))
-					{
-						var exact = results
-							.Where(r => r?.Data != null)
-							.Select(r => new { r.MatchPercent, Data = r.Data, Norm = PlayniteTools.NormalizeGameName(r.Data?.Name ?? string.Empty, true, true) })
-							.Where(x => !string.IsNullOrEmpty(x.Norm) && x.Norm.IsEqual(nQuery))
-							.OrderByDescending(x => x.MatchPercent)
-							.FirstOrDefault();
-
-						if (exact?.Data != null)
-						{
-							if (hltbSettings != null && hltbSettings.UseMatchValue && exact.MatchPercent < hltbSettings.MatchValue && exact.MatchPercent < 98)
-							{
-								if (IsVerboseLoggingEnabled)
-								{
-									try { Logger.Debug($"SearchDataAuto[{traceId}]: exact normalized match rejected by MatchValue score={exact.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-								}
-								return null;
-							}
-
-							if (IsVerboseLoggingEnabled)
-							{
-								try { Logger.Debug($"SearchDataAuto[{traceId}]: selected exact normalized match id={SafeStr(exact.Data?.Id)} title='{SafeStr(exact.Data?.Name)}' score={exact.MatchPercent}"); } catch { }
-							}
-
-							return exact.Data;
-						}
-					}
-				}
-				catch { }
-
-				var best = results[0];
-				if (best?.Data == null)
-				{
-					if (IsVerboseLoggingEnabled)
-					{
-						try { Logger.Debug($"SearchDataAuto[{traceId}]: best result had null data"); } catch { }
-					}
-					return null;
-				}
-
-				try
-				{
-					if (hltbSettings != null && hltbSettings.UseMatchValue && best.MatchPercent < hltbSettings.MatchValue)
-					{
-						if (best.MatchPercent >= 98)
-						{
-							if (IsVerboseLoggingEnabled)
-							{
-								try { Logger.Debug($"SearchDataAuto[{traceId}]: best below MatchValue but accepted via near-perfect safety net score={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-							}
-							return best.Data;
-						}
-
-						if (IsVerboseLoggingEnabled)
-						{
-							try { Logger.Debug($"SearchDataAuto[{traceId}]: rejected by MatchValue bestScore={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-						}
-						return null;
-					}
-				}
-				catch { }
-
-				// 2) Ambiguity handling: if multiple top results are close in score,
-				// fetch details for top candidates and prefer one that actually has times.
-				try
-				{
-					if (results.Count > 1)
-					{
-						var second = results[1];
-						bool ambiguous = false;
-						try
-						{
-							ambiguous = (best.MatchPercent < 100 && second != null && (best.MatchPercent - second.MatchPercent) <= 3);
-						}
-						catch { }
-
-						if (IsVerboseLoggingEnabled)
-						{
-							try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguity check best={best.MatchPercent} second={second?.MatchPercent} ambiguous={ambiguous}"); } catch { }
-						}
-
-						if (ambiguous)
-						{
-							List<HltbSearch> enriched = null;
-							try
-							{
-								enriched = TaskHelpers.RunSyncWithTimeout(() => SearchTwoMethod(gameName, platform, includeExtendedTimes: true), 20000);
-							}
-							catch (Exception ex)
-							{
-								if (IsVerboseLoggingEnabled)
-								{
-									try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: enrichment SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
-								}
-								enriched = null;
-							}
-
-							if (enriched != null && enriched.Count > 0)
-							{
-								if (IsVerboseLoggingEnabled)
-								{
-									try
-									{
-										Logger.Debug($"SearchDataAuto[{traceId}]: enriched count={enriched.Count}");
-										int take = Math.Min(8, enriched.Count);
-										for (int i = 0; i < take; i++)
-										{
-											var r = enriched[i];
-											var d = r?.Data;
-											long ttb = 0;
-											bool hasAnyTime = false;
-											try
-											{
-												ttb = d?.GameHltbData?.TimeToBeat ?? 0;
-												hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
-											}
-											catch { }
-
-											Logger.Debug($"SearchDataAuto[{traceId}]: enriched[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
-										}
-									}
-									catch { }
-								}
-
-								var withTimes = enriched
-									.Where(r => r?.Data?.GameHltbData != null)
-									.Where(r =>
-									{
-										try
-										{
-											return r.Data.GameHltbData.TimeToBeat > 0 || r.Data.GameHltbData.MainStoryClassic > 0 || r.Data.GameHltbData.MainExtraClassic > 0 || r.Data.GameHltbData.CompletionistClassic > 0 || r.Data.GameHltbData.SoloClassic > 0;
-										}
-										catch { return false; }
-									})
-									.OrderByDescending(r => r.MatchPercent)
-									.FirstOrDefault();
-
-								if (withTimes?.Data != null)
-								{
-									if (hltbSettings != null && hltbSettings.UseMatchValue && withTimes.MatchPercent < hltbSettings.MatchValue && withTimes.MatchPercent < 98)
-									{
-										if (IsVerboseLoggingEnabled)
-										{
-											try { Logger.Debug($"SearchDataAuto[{traceId}]: enriched withTimes rejected by MatchValue score={withTimes.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-										}
-										return null;
-									}
-
-									if (IsVerboseLoggingEnabled)
-									{
-										try { Logger.Debug($"SearchDataAuto[{traceId}]: selected enriched withTimes id={SafeStr(withTimes.Data?.Id)} title='{SafeStr(withTimes.Data?.Name)}' score={withTimes.MatchPercent}"); } catch { }
-									}
-									return withTimes.Data;
-								}
-
-								var bestEnriched = enriched[0];
-								if (bestEnriched?.Data != null)
-								{
-									if (hltbSettings != null && hltbSettings.UseMatchValue && bestEnriched.MatchPercent < hltbSettings.MatchValue && bestEnriched.MatchPercent < 98)
-									{
-										if (IsVerboseLoggingEnabled)
-										{
-											try { Logger.Debug($"SearchDataAuto[{traceId}]: bestEnriched rejected by MatchValue score={bestEnriched.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
-										}
-										return null;
-									}
-
-									if (IsVerboseLoggingEnabled)
-									{
-										try { Logger.Debug($"SearchDataAuto[{traceId}]: selected bestEnriched id={SafeStr(bestEnriched.Data?.Id)} title='{SafeStr(bestEnriched.Data?.Name)}' score={bestEnriched.MatchPercent}"); } catch { }
-									}
-									return bestEnriched.Data;
-								}
-							}
-
-							if (best.MatchPercent >= 98)
-							{
-								if (IsVerboseLoggingEnabled)
-								{
-									try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguous but fell back to near-perfect best score={best.MatchPercent} id={SafeStr(best.Data?.Id)}"); } catch { }
-								}
-								return best.Data;
-							}
-						}
-					}
-				}
-				catch { }
-
-				if (IsVerboseLoggingEnabled)
-				{
-					try { Logger.Debug($"SearchDataAuto[{traceId}]: selected best (default) id={SafeStr(best.Data?.Id)} title='{SafeStr(best.Data?.Name)}' score={best.MatchPercent}"); } catch { }
-				}
-
-				return best.Data;
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, true, PluginDatabase?.PluginName); } catch { }
-				return null;
-			}
-		}
-
-		#endregion
-
-		#region user account
-
-		/// <summary>
-		/// Checks if the user is currently logged in to HowLongToBeat (async).
-		/// </summary>
-		/// <returns>True if logged in, otherwise false.</returns>
-		public async Task<bool> GetIsUserLoggedInAsync()
-		{
-			// Avoid getting stuck in a "logged out" state if this method is called before PluginDatabase is loaded.
-			// Use stored cookies directly to check the current session.
-			try
-			{
-				var now = DateTime.UtcNow;
-				if (lastLoginCheckResult != null)
-				{
-					var ttl = lastLoginCheckResult == true ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(1);
-					if (now - lastLoginCheckUtc < ttl)
-					{
-						return lastLoginCheckResult.Value;
-					}
-				}
-
-				int userId = await GetUserId().ConfigureAwait(false);
-				UserId = userId;
-				IsConnected = userId != 0;
-
-				lastLoginCheckUtc = now;
-				lastLoginCheckResult = userId != 0;
-
-				if (IsVerboseLoggingEnabled)
-				{
-					Logger.Debug($"HLTB Auth: GetIsUserLoggedInAsync userId={userId} IsConnected={IsConnected}");
-				}
-
-				return userId != 0;
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-				UserId = 0;
-				IsConnected = false;
-				lastLoginCheckUtc = DateTime.UtcNow;
-				lastLoginCheckResult = false;
-				return false;
-			}
-		}
-
-		public bool GetIsUserLoggedIn()
-		{
-			try
-			{
-				return Task.Run(() => GetIsUserLoggedInAsync()).Result;
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// Initiates the login process for HowLongToBeat.
-		/// </summary>
-		public void Login()
-		{
-			// Use a DispatcherOperation so we can attach the Completed handler cleanly
-			System.Windows.Threading.DispatcherOperation op = null;
-
-			try
-			{
-				op = Application.Current.Dispatcher.BeginInvoke((Action)delegate
-				{
-					Logger.Info("Login()");
-
-					bool cookiesCaptured = false;
-
-					WebViewSettings settings = new WebViewSettings
-					{
-						JavaScriptEnabled = true,
-						WindowHeight = 670,
-						WindowWidth = 490,
-						UserAgent = Web.UserAgent
-					};
-
-					using (IWebView webView = API.Instance.WebViews.CreateView(settings))
-					{
-						webView.LoadingChanged += (s, e) =>
-						{
-							try
-							{
-								Common.LogDebug(true, $"NavigationChanged - {webView.GetCurrentAddress()}");
-
-								if (!cookiesCaptured && webView.GetCurrentAddress().StartsWith(UrlBase + "/user/"))
-								{
-									cookiesCaptured = true;
-									UserLogin = WebUtility.HtmlDecode(webView.GetCurrentAddress().Replace(UrlBase + "/user/", string.Empty));
-									IsConnected = true;
-
-									// Give the embedded WebView a moment to commit cookies.
-									FireAndForget(Task.Run(async () =>
-									{
-										try
-										{
-											await Task.Delay(1000).ConfigureAwait(false);
-										}
-										catch { }
-
-										try
-										{
-											await Application.Current.Dispatcher.InvokeAsync(() =>
-											{
-												try
-												{
-													List<HttpCookie> cookies = CookiesTools.GetWebCookies(deleteCookies: false, webView: webView);
-													bool saved = CookiesTools.SetStoredCookies(cookies);
-													Logger.Info($"HLTB Auth: captured cookies from login webview count={cookies?.Count ?? 0} saved={saved}");
-													LogCookieSummary("login captured", cookies);
-
-													// Invalidate cached login check so next calls re-check if needed.
-													lastLoginCheckResult = null;
-													lastLoginCheckUtc = DateTime.MinValue;
-												}
-												catch (Exception ex)
-												{
-													Common.LogError(ex, false, true, PluginDatabase.PluginName);
-												}
-												finally
-												{
-													try { webView.Close(); } catch { }
-												}
-											});
-										}
-										catch (Exception ex)
-										{
-											try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-											try
-											{
-												var closeOp = Application.Current.Dispatcher.BeginInvoke((Action)(() => { try { webView.Close(); } catch { } }));
-												try { FireAndForget(closeOp?.Task, "login close webview (BeginInvoke)"); } catch { }
-											}
-											catch { }
-										}
-									}), "login captured");
-
-									// (task is fire-and-forget intentionally)
-
-									return;
-								}
-							}
-							catch { }
-						};
-
-						IsConnected = false;
-						webView.Navigate(UrlLogOut);
-						_ = webView.OpenDialog();
-					}
-				});
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-			}
-
-			try
-			{
-				if (op != null)
-				{
-					op.Completed += (s, e) =>
-					{
-						try
-						{
-							if ((bool)IsConnected)
-							{
-								_ = Application.Current.Dispatcher?.BeginInvoke((Action)delegate
-								{
-									try
-									{
-										PluginDatabase.PluginSettings.Settings.UserLogin = UserLogin;
-
-										PluginDatabase.Plugin.SavePluginSettings(PluginDatabase.PluginSettings.Settings);
-
-										FireAndForget(Task.Run(async () =>
-										{
-											try { UserId = await GetUserId().ConfigureAwait(false); } catch { }
-											try { PluginDatabase.RefreshUserData(); } catch { }
-										}), "post-login refresh");
-									}
-									catch (Exception ex)
-									{
-										Common.LogError(ex, false, true, PluginDatabase.PluginName);
-									}
-								});
-							}
-						}
-						catch { }
-					};
-				}
-			}
-			catch { }
-		}
-
-		/// <summary>
-		/// Retrieves the user ID of the currently logged-in user.
-		/// </summary>
-		/// <returns>User ID as integer, or 0 if not logged in.</returns>
-		private async Task<int> GetUserId()
-		{
-			try
-			{
-				List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-				LogCookieSummary("GetUserId stored", cookies);
-
-				if (cookies == null || cookies.Count == 0)
-				{
-					try { Logger.Info("HLTB Auth: no stored cookies available"); } catch { }
-				}
-				string response = await Web.DownloadPageText(UrlUser, cookies);
-				dynamic t = Serialization.FromJson<dynamic>(response);
-
-				int userId = response == "{}" ? 0 : t?.data[0]?.user_id ?? 0;
-				if (IsVerboseLoggingEnabled)
-				{
-					Logger.Debug($"HLTB Auth: GetUserId responseLen={response?.Length ?? 0} userId={userId}");
-				}
-
-				return userId;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false);
-				return 0;
-			}
-		}
-
-		/// <summary>
-		/// Retrieves the list of games for the current user.
-		/// </summary>
-		/// <returns>Returns a <see cref="UserGamesList"/> object.</returns>
-		private async Task<UserGamesList> GetUserGamesList()
-		{
-			try
-			{
-				List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-
-				UserGamesListParam userGamesListParam = new UserGamesListParam { UserId = UserId };
-				string payload = Serialization.ToJson(userGamesListParam);
-
-				string json = await PostJson(string.Format(UrlUserGamesList, UserId), payload, cookies);
-				_ = Serialization.TryFromJson(json, out UserGamesList userGamesList);
-
-				return userGamesList;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Converts a <see cref="GamesList"/> entry to a <see cref="TitleList"/>.
-		/// </summary>
-		/// <param name="gamesList">The games list entry.</param>
-		/// <returns>Returns a <see cref="TitleList"/> object.</returns>
-		private TitleList GetTitleList(GamesList gamesList)
-		{
-			try
-			{
-				_ = DateTime.TryParse(gamesList.DateUpdated, out DateTime lastUpdate);
-				_ = DateTime.TryParse(gamesList.DateComplete, out DateTime completion);
-				_ = DateTime.TryParse(gamesList.DateStart, out DateTime dateStart);
-				DateTime? completionFinal = null;
-				if (completion != default)
-				{
-					completionFinal = completion;
-				}
-
-				TitleList titleList = new TitleList
-				{
-					UserGameId = gamesList.Id.ToString(),
-					GameName = gamesList.CustomTitle,
-					Platform = gamesList.Platform,
-					Id = gamesList.GameId.ToString(),
-					CurrentTime = gamesList.InvestedPro,
-					IsReplay = gamesList.PlayCount == 2,
-					IsRetired = gamesList.ListRetired == 1,
-					Storefront = gamesList.PlayStorefront,
-					StartDate = dateStart,
-					LastUpdate = lastUpdate,
-					Completion = completionFinal,
-					HltbUserData = new HltbData
-					{
-						GameType = gamesList.GameType.IsEqual("game") ? GameType.Game : gamesList.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
-						MainStoryClassic = gamesList.CompMain,
-						MainExtraClassic = gamesList.CompPlus,
-						CompletionistClassic = gamesList.Comp100,
-						SoloClassic = 0,
-						CoOpClassic = gamesList.InvestedCo,
-						VsClassic = gamesList.InvestedMp
-					},
-					GameStatuses = new List<GameStatus>()
-				};
-
-				if (gamesList.ListBacklog == 1)
-				{
-					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Backlog });
-				}
-
-				if (gamesList.ListComp == 1)
-				{
-					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Completed });
-				}
-
-				if (gamesList.ListCustom == 1)
-				{
-					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.CustomTab });
-				}
-
-				if (gamesList.ListPlaying == 1)
-				{
-					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Playing });
-				}
-
-				if (gamesList.ListReplay == 1)
-				{
-					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Replays });
-				}
-
-				if (gamesList.ListRetired == 1)
-				{
-					titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Retired });
-				}
-
-				return titleList;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Retrieves the edit data for a specific user game entry.
-		/// </summary>
-		/// <param name="gameName">The name of the game.</param>
-		/// <param name="userGameId">The user game ID.</param>
-		/// <returns>Returns an <see cref="EditData"/> object.</returns>
-		public async Task<EditData> GetEditData(string gameName, string userGameId)
-		{
-			Logger.Info($"GetEditData({gameName}, {userGameId})");
-			try
-			{
-				List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-
-				string response = await Web.DownloadStringData(string.Format(UrlPostDataEdit, userGameId), cookies);
-				if (string.IsNullOrEmpty(response) || !response.Contains("__NEXT_DATA__"))
-				{
-					Logger.Warn($"No EditData for {gameName} - {userGameId}");
-					return null;
-				}
-
-				string jsonData = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
-				_ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
-				if (parseEx != null)
-				{
-					Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
-				}
-
-				return next_data?.Props?.PageProps?.EditData?.UserId != null
-					? next_data.Props.PageProps.EditData
-					: throw new Exception($"No EditData find for {gameName} - {userGameId}");
-			}
-			catch (Exception ex)
-			{
-				if (IsFirst)
-				{
-					IsFirst = false;
-					return await GetEditData(gameName, userGameId);
-				}
-				else
-				{
-					Common.LogError(ex, false, true, PluginDatabase.PluginName);
-					return null;
-				}
-			}
-		}
-
-		/// <summary>
-		/// Loads user stats from the local file.
-		/// </summary>
-		/// <returns>Returns a <see cref="HltbUserStats"/> object.</returns>
-		public HltbUserStats LoadUserData()
-		{
-			string pathHltbUserStats = Path.Combine(PluginDatabase.Plugin.GetPluginUserDataPath(), "HltbUserStats.json");
-			HltbUserStats hltbDataUser = new HltbUserStats();
-
-			if (File.Exists(pathHltbUserStats))
-			{
-				try
-				{
-					if (!Serialization.TryFromJsonFile(pathHltbUserStats, out hltbDataUser))
-					{
-						return new HltbUserStats();
-					}
-					hltbDataUser.TitlesList = hltbDataUser.TitlesList.Where(x => x != null).ToList();
-				}
-				catch (Exception ex)
-				{
-					Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				}
-			}
-
-			return hltbDataUser;
-		}
-
-		/// <summary>
-		/// Retrieves the user data from HowLongToBeat (async).
-		/// </summary>
-		/// <returns>Returns a <see cref="HltbUserStats"/> object, or null if not logged in.</returns>
-		public async Task<HltbUserStats> GetUserDataAsync()
-		{
-			if (await GetIsUserLoggedInAsync().ConfigureAwait(false))
-			{
-				HltbUserStats hltbUserStats = new HltbUserStats
-				{
-					Login = UserLogin.IsNullOrEmpty() ? PluginDatabase.Database.UserHltbData.Login : UserLogin,
-					UserId = (UserId == 0) ? PluginDatabase.Database.UserHltbData.UserId : UserId,
-					TitlesList = new List<TitleList>()
-				};
-
-				UserGamesList userGamesList = null;
-				try { userGamesList = await GetUserGamesList().ConfigureAwait(false); } catch { userGamesList = null; }
-				if (userGamesList == null)
-				{
-					return null;
-				}
-
-				try
-				{
-					userGamesList.Data.GamesList.ForEach(x =>
-					{
-						TitleList titleList = GetTitleList(x);
-						hltbUserStats.TitlesList.Add(titleList);
-					});
-				}
-				catch (Exception ex)
-				{
-					Common.LogError(ex, false, true, PluginDatabase.PluginName);
-					return null;
-				}
-
-				return hltbUserStats;
-			}
-			else
-			{
-				API.Instance.Notifications.Add(new NotificationMessage(
-					$"{PluginDatabase.PluginName}-Import-Error",
-					PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
-					NotificationType.Error,
-					() => PluginDatabase.Plugin.OpenSettingsView()
-				));
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Synchronous wrapper for backwards compatibility; runs async method on thread-pool.
-		/// </summary>
-		public HltbUserStats GetUserData()
-		{
-			try
-			{
-				var task = Task.Run(() => GetUserDataAsync());
-				if (!task.Wait(15000))
-				{
-					try { Logger.Warn("GetUserData timed out"); } catch { }
-					return null;
-				}
-				return task.Result;
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Finds the existing user game ID for a given game ID (async).
-		/// </summary>
-		public async Task<string> FindIdExistingAsync(string gameId)
-		{
-			try
-			{
-				var ug = await GetUserGamesList().ConfigureAwait(false);
-				return ug?.Data?.GamesList?.Find(x => x.GameId.ToString().IsEqual(gameId))?.Id.ToString() ?? null;
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Synchronous wrapper for backwards compatibility.
-		/// </summary>
-		public string FindIdExisting(string gameId)
-		{
-			try
-			{
-				var task = Task.Run(() => FindIdExistingAsync(gameId));
-				if (!task.Wait(15000))
-				{
-					try { Logger.Warn($"FindIdExisting({gameId}) timed out"); } catch { }
-					return null;
-				}
-				return task.Result;
-			}
-			catch (Exception ex)
-			{
-				try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Synchronous helper: get TitleList for a specific game id from user data.
-		/// </summary>
-		public TitleList GetUserData(string gameId)
-		{
-			try
-			{
-				var task = Task.Run(() => GetUserDataAsync());
-				if (!task.Wait(15000))
-				{
-					try { Logger.Warn($"GetUserData (sync) timed out"); } catch { }
-					return null;
-				}
-				var userData = task.Result;
-				return userData?.TitlesList?.Find(x => x.Id == gameId);
-			}
-			catch (Exception)
-			{
-				return null;
-			}
-		}
-
-		public bool EditIdExist(string userGameId)
-		{
-			try
-			{
-				var task = Task.Run(() => GetUserGamesList());
-				if (!task.Wait(15000))
-				{
-					try { Logger.Warn($"EditIdExist({userGameId}) timed out"); } catch { }
-					return false;
-				}
-				var ug = task.Result;
-				return ug?.Data?.GamesList?.Find(x => x.Id.ToString().IsEqual(userGameId))?.Id != null;
-			}
-			catch
-			{
-				return false;
-			}
-		}
-
-		#endregion
-
-
-		/// <summary>
-		/// Submits the current game data to the HowLongToBeat website.
-		/// </summary>
-		/// <param name="game">The Playnite game object.</param>
-		/// <param name="editData">The data to submit.</param>
-		/// <returns>True if submission is successful, otherwise false.</returns>
-		public async Task<bool> ApiSubmitData(Game game, EditData editData)
-		{
-			if (GetIsUserLoggedIn() && editData.UserId != 0 && editData.GameId != 0)
-			{
-				try
-				{
-					List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
-					string payload = Serialization.ToJson(editData);
-					List<KeyValuePair<string, string>> moreHeaders = new List<KeyValuePair<string, string>>
-					{
-						new KeyValuePair<string, string>("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")
-					};
-					string response = await PostJson(UrlPostData, payload, cookies);
-
-					if (string.IsNullOrEmpty(response))
-					{
-						API.Instance.Notifications.Add(new NotificationMessage(
-							$"{PluginDatabase.PluginName}-{game.Id}-Error",
-							PluginDatabase.PluginName + Environment.NewLine + game.Name,
-							NotificationType.Error
-						));
-						Logger.Warn($"ApiSubmitData: empty response when posting data for game {game.Id}");
-						return false;
-					}
-
-					try
-					{
-						var success = false;
-						_ = Serialization.TryFromJson(response, out dynamic respObj);
-						if (respObj != null)
-						{
-							try
-							{
-								if (respObj.error != null)
-								{
-									string msg = string.Empty;
-									try { msg = respObj.error[0]?.ToString() ?? respObj.error.ToString(); } catch { msg = respObj.error.ToString(); }
-									API.Instance.Notifications.Add(new NotificationMessage(
-										$"{PluginDatabase.PluginName}-{game.Id}-Error",
-										PluginDatabase.PluginName + Environment.NewLine + game.Name + (msg.IsNullOrEmpty() ? string.Empty : Environment.NewLine + msg),
-										NotificationType.Error
-									));
-									Logger.Warn($"ApiSubmitData error for game {game.Id}: {msg}");
-								}
-								else if (respObj.errors != null)
-								{
-									string msg = respObj.errors.ToString();
-									API.Instance.Notifications.Add(new NotificationMessage(
-										$"{PluginDatabase.PluginName}-{game.Id}-Error",
-										PluginDatabase.PluginName + Environment.NewLine + game.Name + Environment.NewLine + msg,
-										NotificationType.Error
-									));
-									Logger.Warn($"ApiSubmitData errors for game {game.Id}: {msg}");
-								}
-								else
-								{
-									success = true;
-								}
-							}
-							catch (Exception ex)
-							{
-								Common.LogError(ex, false, false, PluginDatabase.PluginName);
-							}
-						}
-						else
-						{
-							Logger.Debug("ApiSubmitData: non-JSON response received; treating as success");
-							success = true;
-						}
-
-						if (success)
-						{
-							PluginDatabase.RefreshUserData(editData.GameId.ToString());
-							return true;
-						}
-						else
-						{
-							return false;
-						}
-					}
-					catch (Exception ex)
-					{
-						Common.LogError(ex, false, true, PluginDatabase.PluginName);
-						return false;
-					}
-				}
-				catch (Exception ex)
-				{
-					Common.LogError(ex, false, true, PluginDatabase.PluginName);
-					return false;
-				}
-			}
-			else
-			{
-				API.Instance.Notifications.Add(new NotificationMessage(
-					$"{PluginDatabase.PluginName}-DataUpdate-Error",
-					PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
-					NotificationType.Error,
-					() => PluginDatabase.Plugin.OpenSettingsView()
-				));
-				return false;
-			}
-		}
-
-		/// <summary>
-		/// Updates the stored cookies for the current user session.
-		/// </summary>
-		public void UpdatedCookies()
-		{
-			try
-			{
-				// Run wait off the UI thread, then invoke UI work when ready
-				FireAndForget(Task.Run(async () =>
-				{
-					var sw = System.Diagnostics.Stopwatch.StartNew();
-					const int maxWaitMs = 60000; // 60s max wait for database load
-					while (!PluginDatabase.IsLoaded)
-					{
-						await Task.Delay(100).ConfigureAwait(false);
-						if (sw.ElapsedMilliseconds > maxWaitMs)
-						{
-							try { if (IsVerboseLoggingEnabled) Logger.Warn("Timeout waiting for PluginDatabase.IsLoaded in UpdatedCookies"); } catch { }
-							break;
-						}
-					}
-
-					try
-					{
-						await Application.Current.Dispatcher.InvokeAsync(() =>
-						{
-							try
-							{
-								if (PluginDatabase.Database.UserHltbData?.UserId != null && PluginDatabase.Database.UserHltbData.UserId != 0)
-								{
-									Logger.Info($"Refresh HowLongToBeat user cookies");
-									List<HttpCookie> cookies = CookiesTools.GetNewWebCookies(new List<string> { UrlBase, UrlUser }, true);
-									_ = CookiesTools.SetStoredCookies(cookies);
-								}
-							}
-							catch (Exception ex)
-							{
-								Common.LogError(ex, false, true, PluginDatabase.PluginName);
-							}
-						});
-					}
-					catch (Exception ex)
-					{
-						Common.LogError(ex, false, true, PluginDatabase.PluginName);
-					}
-				}), "UpdatedCookies");
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-			}
-		}
-
-		/// <summary>
-		/// Try to extract script src URLs using HtmlAgilityPack via reflection. Returns null on failure.
-		/// Reflection is used because HAP is an optional dependency for the host application.
-		/// </summary>
-		private List<string> ExtractScriptUrlsWithHap(string html)
-		{
-			if (!HapAvailable || HapDocType == null || string.IsNullOrEmpty(html))
-			{
-				return null;
-			}
-
-			try
-			{
-				// Create HtmlDocument instance
-				dynamic doc = Activator.CreateInstance(HapDocType);
-				var loadHtml = HapDocType.GetMethod("LoadHtml");
-				loadHtml.Invoke(doc, new object[] { html });
-
-				var documentNode = HapDocType.GetProperty("DocumentNode").GetValue(doc);
-				var selectNodes = documentNode.GetType().GetMethod("SelectNodes", new Type[] { typeof(string) });
-				var nodes = selectNodes.Invoke(documentNode, new object[] { "//script[@src]" }) as System.Collections.IEnumerable;
-				if (nodes == null) return new List<string>();
-
-				var urls = new List<string>();
-				foreach (var node in nodes)
-				{
-					try
-					{
-						var attrsProp = node.GetType().GetProperty("Attributes");
-						if (attrsProp == null) continue;
-						var attrs = attrsProp.GetValue(node);
-						if (attrs == null) continue;
-						var getAttr = attrs.GetType().GetMethod("Get", new Type[] { typeof(string) });
-						if (getAttr == null) continue;
-						var srcAttr = getAttr.Invoke(attrs, new object[] { "src" });
-						if (srcAttr != null)
-						{
-							var valProp = srcAttr.GetType().GetProperty("Value");
-							var val = valProp != null ? valProp.GetValue(srcAttr) as string : null;
-							if (!string.IsNullOrEmpty(val)) urls.Add(val);
-						}
-					}
-					catch { /* ignore per-node errors */ }
-				}
-
-				return urls;
-			}
-			catch (Exception ex)
-			{
-				try { Logger.Warn(ex, "HLTB: HtmlAgilityPack reflection extraction failed"); } catch { }
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Posts JSON payload to URL, optionally with cookies, and returns response string.
-		/// </summary>
-		private async Task<string> PostJson(string url, string payload, List<HttpCookie> cookies = null, CancellationToken cancellationToken = default)
-		{
-			try
-			{
-				HttpClientHandler handler = null;
-				if (cookies != null)
-				{
-					try
-					{
-						var mi = typeof(CommonPluginsShared.Web).GetMethod("CreateCookiesContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
-						if (mi != null)
-						{
-							var container = mi.Invoke(null, new object[] { cookies }) as CookieContainer;
-							handler = new HttpClientHandler { CookieContainer = container };
-						}
-					}
-					catch { handler = new HttpClientHandler(); }
-				}
-
-				HttpClient client = null;
-				bool disposeClient = false;
-				try
-				{
-					if (handler != null)
-					{
-						client = new HttpClient(handler)
-						{
-							Timeout = System.Threading.Timeout.InfiniteTimeSpan
-						};
-						disposeClient = true;
-					}
-					else
-					{
-						// Reuse the shared instance-level httpClient to avoid socket exhaustion
-						client = httpClient ?? new HttpClient();
-						disposeClient = false;
-					}
-
-					if (handler != null)
-					{
-						try { client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent); } catch { }
-						try { client.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
-					}
-
-					var content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
-					using (var resp = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false))
-					{
-						if (!resp.IsSuccessStatusCode)
-						{
-							try { Logger.Warn($"HTTP {(int)resp.StatusCode} posting to {url}"); } catch { }
-							return string.Empty;
-						}
-
-						return await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
-					}
-				}
-				finally
-				{
-					if (disposeClient && client != null)
-					{
-						try { client.Dispose(); } catch { }
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, $"Error posting to {url}");
-				return string.Empty;
-			}
-		}
-
-		/// <summary>
-		/// Posts JSON payload using shared HttpClient and returns tuple (responseBody, statusCode, retryAfterHeader).
-		/// This is a local replacement for CommonPluginsShared.Web.PostJsonWithSharedClientWithStatus when the submodule isn't available.
-		/// </summary>
-		private async Task<(string body, int status, string retry)> PostJsonWithSharedClientWithStatus(string url, string payload, List<HttpHeader> headers = null, CancellationToken cancellationToken = default)
-		{
-			try
-			{
-				using (var request = new HttpRequestMessage(HttpMethod.Post, url))
-				{
-					request.Content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
-
-					if (headers != null)
-					{
-						foreach (var h in headers)
-						{
-							try
-							{
-								// Try to add to request headers; if invalid, try content headers
-								if (!request.Headers.TryAddWithoutValidation(h.Key, h.Value))
-								{
-									try { request.Content?.Headers.TryAddWithoutValidation(h.Key, h.Value); } catch { }
-								}
-							}
-							catch { }
-						}
-					}
-
-					using (var resp = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
-					{
-						int status = (int)resp.StatusCode;
-						string retry = null;
-						try
-						{
-							if (resp.Headers.TryGetValues("Retry-After", out var vals))
-							{
-								retry = vals.FirstOrDefault();
-							}
-						}
-						catch { }
-
-						string body = string.Empty;
-						try { body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false); } catch { body = string.Empty; }
-
-						if (!resp.IsSuccessStatusCode)
-						{
-							try { Logger.Warn($"HTTP {status} posting to {url}"); } catch { }
-						}
-
-						return (body, status, retry);
-					}
-				}
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, $"Error posting to {url}");
-				return (string.Empty, 0, (string)null);
-			}
-		}
-		private static readonly Regex _scriptSrcRegex = new Regex("<script[^>]*src=[\\\"']([^\\\"']+)[\\\"'][^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-		private static Regex MyRegex() => _scriptSrcRegex;
-	}
+		private async Task<string> GetAuthToken(string apiEndpoint)
+        {
+            try
+            {
+                // Double-checked locking: quick snapshot first to avoid locking in common case
+                var snapshotToken = CachedAuthToken;
+                var snapshotExpiry = CachedAuthTokenExpiry;
+                if (!string.IsNullOrEmpty(snapshotToken) && DateTime.UtcNow < snapshotExpiry)
+                {
+                    return snapshotToken;
+                }
+
+                // Re-check under lock to avoid race with a concurrent writer
+                lock (AuthTokenSync)
+                {
+                    if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
+                    {
+                        return CachedAuthToken;
+                    }
+                }
+
+                List<HttpHeader> headers = new List<HttpHeader>
+                {
+                    new HttpHeader { Key = "Referer", Value = UrlBase }
+                };
+                string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+                string response = null;
+                try
+                {
+                    using (var cts = new CancellationTokenSource(ScriptDownloadTimeoutMs))
+                    using (var request = new HttpRequestMessage(HttpMethod.Get, url))
+                    {
+                        try { request.Headers.Add("Referer", UrlBase); } catch { }
+
+                        using (var resp = await httpClient.SendAsync(request, cts.Token).ConfigureAwait(false))
+                        {
+                            if (!resp.IsSuccessStatusCode)
+                            {
+                                try { Logger.Warn($"HTTP {(int)resp.StatusCode} downloading auth init {url}"); } catch { }
+                                return null;
+                            }
+
+                            response = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        }
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    try { Logger.Warn($"Timeout {ScriptDownloadTimeoutMs}ms downloading auth init {url}"); } catch { }
+                    return null;
+                }
+                catch (Exception ex)
+                {
+                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                    return null;
+                }
+
+                var data = Serialization.FromJson<Dictionary<string, string>>(response);
+                if (data != null && data.TryGetValue("token", out string token))
+                {
+                    lock (AuthTokenSync)
+                    {
+                        // Final re-check before writing to shared fields
+                        if (!string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry)
+                        {
+                            return CachedAuthToken;
+                        }
+                        CachedAuthToken = token;
+                        CachedAuthTokenExpiry = DateTime.UtcNow.AddSeconds(90);
+                    }
+                    return token;
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+            }
+            return null;
+        }
+
+
+        /// <summary>
+        /// Searches for games on HowLongToBeat by name and platform.
+        /// </summary>
+        /// <param name="name">Game name to search for.</param>
+        /// <param name="platform">Optional platform filter.</param>
+        /// <returns>Returns a list of <see cref="HltbDataUser"/> matching the search.</returns>
+        private async Task<List<HltbDataUser>> Search(string name, string platform = "")
+        {
+            try
+            {
+                SearchResult searchResult = await ApiSearch(name, platform);
+
+                List<HltbDataUser> search = searchResult?.Data?.Select(x =>
+                    new HltbDataUser
+                    {
+                        Name = x.GameName,
+                        Id = x.GameId.ToString(),
+                        UrlImg = string.Format(UrlGameImg, x.GameImage),
+                        Url = string.Format(UrlGame, x.GameId),
+                        Platform = x.ProfilePlatform,
+                        GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
+                        GameHltbData = new HltbData
+                        {
+                            GameType = x.GameType.IsEqual("game") ? GameType.Game : x.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
+                            MainStoryClassic = x.CompMain,
+                            MainExtraClassic = x.CompPlus,
+                            CompletionistClassic = x.Comp100,
+                            SoloClassic = x.CompAll,
+                            CoOpClassic = x.InvestedCo,
+                            VsClassic = x.InvestedMp
+                        },
+                        NeedsDetails = !((x.CompMain > 0) || (x.CompAll > 0) || (x.CompPlus > 0) || (x.Comp100 > 0))
+                    }
+                )?.ToList() ?? new List<HltbDataUser>();
+
+                if (search.Count != 0)
+                {
+                    try
+                    {
+                        int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+                        await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "Search");
+                    }
+                    catch { }
+
+                    var tasks = search.Select(async x =>
+                    {
+                        bool acquiredGameSemaphore = false;
+                        try
+                        {
+                            try
+                            {
+                                try
+                                {
+                                    int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+                                    int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
+                                    int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
+                                    LogDebugVerbose($"Search: waiting semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
+                                }
+                                catch { }
+                                var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
+                                if (!acquired)
+                                {
+                                    Logger.Warn($"Search: timeout waiting for game data semaphore for id={x.Id}");
+                                    return;
+                                }
+                                acquiredGameSemaphore = true;
+                                try
+                                {
+                                    int targetGameLog = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+                                    int availableGameLog = DynamicSemaphore?.CurrentCount ?? 0;
+                                    int inFlightGameLog = Math.Max(0, targetGameLog - availableGameLog);
+                                    LogDebugVerbose($"Search: acquired semaphore for id={x.Id} target={targetGameLog} currentLimit={CurrentSemaphoreLimit} available={availableGameLog} inFlight={inFlightGameLog}");
+                                }
+                                catch { }
+                            }
+                            catch (Exception ex)
+                            {
+                                Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                            }
+                            try
+                            {
+                                try
+                                {
+                                    bool hasCoreTimes = (x.GameHltbData != null) && (
+                                        (x.GameHltbData.MainStoryClassic > 0) ||
+                                        (x.GameHltbData.MainStoryAverage > 0) ||
+                                        (x.GameHltbData.MainStoryMedian > 0)
+                                    );
+
+                                    if (hasCoreTimes)
+                                    {
+                                        LogDebugVerbose($"Search: skipping GetGameData for id={x.Id} (search result has times)");
+                                        x.NeedsDetails = false;
+                                    }
+                                    else
+                                    {
+                                        using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
+                                        {
+                                            try
+                                            {
+                                                x.GameHltbData = await GetGameData(x.Id, ctsGame.Token);
+                                                x.NeedsDetails = false;
+                                            }
+                                            catch (OperationCanceledException)
+                                            {
+                                                Logger.Warn($"Timeout {GameDataDownloadTimeoutMs}ms getting game data for {x.Id}");
+                                                x.GameHltbData = null;
+                                            }
+                                        }
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                                    x.GameHltbData = null;
+                                }
+                            }
+                            finally
+                            {
+                                if (acquiredGameSemaphore)
+                                {
+                                    try
+                                    {
+                                        DynamicSemaphore.Release();
+                                    }
+                                    catch { }
+                                }
+                                LogDebugVerbose($"Search: released semaphore for id={x.Id}");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                        }
+                    }).ToArray();
+
+                    await Task.WhenAll(tasks);
+                    try
+                    {
+                        LogDebugVerbose($"Search summary: persistentCacheHits={PersistentCacheHits}, inMemoryHits={InMemoryCacheHits}, pageFetches={PageFetches}");
+                    }
+                    catch { }
+                }
+                return search;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                return new List<HltbDataUser>();
+            }
+        }
+
+        /// <summary>
+        /// Performs two search methods (normalized and original name) and merges results.
+        /// </summary>
+        /// <param name="name">Game name to search for.</param>
+        /// <param name="platform">Optional platform filter.</param>
+        /// <returns>Returns a list of <see cref="HltbSearch"/> with match percentages.</returns>
+        public async Task<List<HltbSearch>> SearchTwoMethod(string name, string platform = "", bool includeExtendedTimes = false)
+        {
+            // Apply manual aliases (exact normalized match) to support paired releases (e.g. Pokemon versions).
+            try
+            {
+                var settings = PluginDatabase?.PluginSettings?.Settings;
+                var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
+                var aliased = GameNameAliases.ApplyAlias(name, settings, userDataPath);
+                if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(name))
+                {
+                    LogDebugVerbose($"HLTB aliases: '{SafeStr(name)}' -> '{SafeStr(aliased)}'");
+                    name = aliased;
+                }
+            }
+            catch { }
+
+            string normalized = PlayniteTools.NormalizeGameName(name, true, true);
+
+            List<HltbDataUser> dataSearch = null;
+            List<HltbDataUser> dataSearchNormalized = null;
+
+            try
+            {
+                if (!string.IsNullOrEmpty(normalized) && !normalized.Equals(name, StringComparison.Ordinal))
+                {
+                    var t1 = Search(name, platform);
+                    var t2 = Search(normalized, platform);
+                    await Task.WhenAll(t1, t2).ConfigureAwait(false);
+                    dataSearch = t1.Result ?? new List<HltbDataUser>();
+                    dataSearchNormalized = t2.Result ?? new List<HltbDataUser>();
+                }
+                else
+                {
+                    dataSearch = await Search(name, platform);
+                    dataSearchNormalized = new List<HltbDataUser>();
+                }
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+                dataSearch = dataSearch ?? new List<HltbDataUser>();
+                dataSearchNormalized = dataSearchNormalized ?? new List<HltbDataUser>();
+            }
+
+            var dataSearchFinal = new List<HltbDataUser>();
+            if (dataSearch != null) dataSearchFinal.AddRange(dataSearch);
+            if (dataSearchNormalized != null) dataSearchFinal.AddRange(dataSearchNormalized);
+
+            dataSearchFinal = dataSearchFinal.GroupBy(x => x.Id).Select(x => x.First()).ToList();
+
+            string searchNameLower = (name ?? string.Empty).ToLower();
+            var results = dataSearchFinal
+                .Where(x => x != null)
+                .Select(x => new HltbSearch
+                {
+                    MatchPercent = Fuzz.Ratio(searchNameLower, (x.Name ?? string.Empty).ToLower()),
+                    Data = x
+                })
+                .OrderByDescending(x => x.MatchPercent)
+                .ToList();
+
+            if (includeExtendedTimes)
+            {
+                try
+                {
+                    const int maxDetails = 20;
+                    var targets = results
+                        .Select(r => r?.Data)
+                        .Where(x => x != null && !string.IsNullOrEmpty(x.Id))
+                        .Take(maxDetails)
+                        .ToList();
+
+                    if (targets.Count > 0)
+                    {
+                        try
+                        {
+                            int target = ConcurrencyController?.TargetConcurrency ?? MaxParallelGameDataDownloads;
+                            await AdjustSemaphoreLimit(DynamicSemaphore, () => CurrentSemaphoreLimit, l => CurrentSemaphoreLimit = l, target, ConcurrencySync, "SearchTwoMethod+Details");
+                        }
+                        catch { }
+
+                        var tasks = targets.Select(async x =>
+                        {
+                            bool acquiredGameSemaphore = false;
+                            try
+                            {
+                                var acquired = await DynamicSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
+                                if (!acquired)
+                                {
+                                    return;
+                                }
+                                acquiredGameSemaphore = true;
+
+                                using (var ctsGame = new CancellationTokenSource(GameDataDownloadTimeoutMs))
+                                {
+                                    try
+                                    {
+                                        var details = await GetGameData(x.Id, ctsGame.Token);
+                                        if (details != null)
+                                        {
+                                            x.GameHltbData = details;
+                                            x.NeedsDetails = false;
+                                        }
+                                    }
+                                    catch (OperationCanceledException)
+                                    {
+                                        // Ignore timeout; keep basic search data
+                                    }
+                                    catch
+                                    {
+                                        // Ignore; keep basic search data
+                                    }
+                                }
+                            }
+                            finally
+                            {
+                                if (acquiredGameSemaphore)
+                                {
+                                    try { DynamicSemaphore.Release(); } catch { }
+                                }
+                            }
+                        }).ToArray();
+
+                        await Task.WhenAll(tasks).ConfigureAwait(false);
+                    }
+                }
+                catch
+                {
+                    // Best-effort enrichment; never fail the whole search.
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Performs an API search for games.
+        /// </summary>
+        /// <param name="name">Game name to search for.</param>
+        /// <param name="platform">Optional platform filter.</param>
+        /// <returns>Returns a <see cref="SearchResult"/> object.</returns>
+        private async Task<SearchResult> ApiSearch(string name, string platform = "")
+        {
+            try { EnsureMonitoringStarted(); } catch { }
+            int GetSearchTarget()
+            {
+                try
+                {
+                    int baseTarget = MaxParallelSearches;
+                    lock (BackoffSync)
+                    {
+                        if (SearchBackoffLimit > 0 && DateTime.UtcNow < SearchBackoffUntil)
+                        {
+                            return Math.Min(baseTarget, SearchBackoffLimit);
+                        }
+                    }
+                    return baseTarget;
+                }
+                catch
+                {
+                    return SearchConcurrencyController?.TargetConcurrency ?? MaxParallelSearches;
+                }
+            }
+
+            try
+            {
+                string cacheKey = (name ?? string.Empty) + "|" + (platform ?? string.Empty);
+                if (SearchCache.TryGetValue(cacheKey, out SearchResult cachedResult))
+                {
+                    try { LogDebugVerbose($"ApiSearch cache hit for '{name}' platform='" + platform + "'"); } catch { }
+                    return cachedResult;
+                }
+
+                List<HttpHeader> httpHeaders = new List<HttpHeader>
+                {
+                    new HttpHeader { Key = "User-Agent", Value = Web.UserAgent },
+                    new HttpHeader { Key = "Origin", Value = UrlBase },
+                    new HttpHeader { Key = "Referer", Value = UrlBase }
+                };
+
+                SearchParam searchParam = new SearchParam
+                {
+                    SearchTerms = name.Split(' ').ToList(),
+                    SearchOptions = new SearchOptions { Games = new Games { Platform = platform } }
+                };
+
+                SearchResult searchResult = null;
+                string serializedBody = Serialization.ToJson(searchParam);
+                string searchUrl = await GetSearchUrl();
+                bool tokenReused = !string.IsNullOrEmpty(CachedAuthToken) && DateTime.UtcNow < CachedAuthTokenExpiry;
+                string token = await GetAuthToken(searchUrl);
+                if (!token.IsNullOrEmpty())
+                {
+                    httpHeaders.Add(new HttpHeader { Key = "x-auth-token", Value = token });
+                }
+
+                bool acquired = false;
+                try
+                {
+                    try
+                    {
+                        try
+                        {
+                            int target = GetSearchTarget();
+                            await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, target, SearchConcurrencySync, "ApiSearch+Initial");
+                        }
+                        catch { }
+
+                        try
+                        {
+                            int targetLog = GetSearchTarget();
+                            int availableLog = SearchSemaphore?.CurrentCount ?? 0;
+                            int inFlightLog = Math.Max(0, targetLog - availableLog);
+                            LogDebugVerbose($"ApiSearch: waiting search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
+                        }
+                        catch { }
+                        bool waitOk = true;
+                        if (SearchSemaphore != null)
+                        {
+                            waitOk = await SearchSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
+                        }
+                        if (!waitOk)
+                        {
+                            Logger.Warn($"ApiSearch: timeout waiting search semaphore for '{name}'");
+                            return null;
+                        }
+                        acquired = true;
+                        try
+                        {
+                            int targetLog = GetSearchTarget();
+                            int availableLog = SearchSemaphore?.CurrentCount ?? 0;
+                            int inFlightLog = Math.Max(0, targetLog - availableLog);
+                            LogDebugVerbose($"ApiSearch: acquired search semaphore for '{name}' target={targetLog} currentLimit={CurrentSearchLimit} available={availableLog} inFlight={inFlightLog}");
+                        }
+                        catch { }
+                    }
+                    catch (Exception ex)
+                    {
+                        Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                    }
+
+                    var sw = Stopwatch.StartNew();
+                    // Use local helper to avoid dependency on optional CommonPluginsShared submodule.
+                    // Allow the POST to be cancelled/timeout independently of the shared HttpClient timeout by using a bounded CTS.
+                    (string body, int status, string retry) postResult;
+                    using (var postCts = new CancellationTokenSource(TimeSpan.FromSeconds(30)))
+                    {
+                        postResult = await PostJsonWithSharedClientWithStatus(UrlBase + searchUrl, serializedBody, httpHeaders, postCts.Token);
+                    }
+                    sw.Stop();
+                    string json = postResult.body ?? string.Empty;
+                    int statusCode = postResult.status;
+                    string retryAfterHeader = postResult.retry;
+
+                    try
+                    {
+                        if (statusCode == 429)
+                        {
+                            int backoffSeconds = 30;
+                            if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsedSeconds))
+                            {
+                                backoffSeconds = Math.Max(1, parsedSeconds);
+                            }
+
+                            lock (BackoffSync)
+                            {
+                                int newLimit = Math.Max(1, CurrentSearchLimit / 2);
+                                SearchBackoffLimit = newLimit;
+                                SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
+                            }
+
+                            Logger.Warn($"ApiSearch: received 429 for '{name}'. Immediate backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
+                        }
+                    }
+                    catch { }
+
+                    try
+                    {
+                        try
+                        {
+                            RecentSearchSamples.Enqueue(sw.ElapsedMilliseconds);
+                            while (RecentSearchSamples.Count > RecentSamplesWindow)
+                            {
+                                RecentSearchSamples.TryDequeue(out _);
+                            }
+                        }
+                        catch { }
+
+                        try
+                        {
+                            RecentSearchStatusCodes.Enqueue(statusCode);
+                            while (RecentSearchStatusCodes.Count > RecentStatusWindow)
+                            {
+                                RecentSearchStatusCodes.TryDequeue(out _);
+                            }
+                        }
+                        catch { }
+
+                        LogDebugVerbose($"ApiSearch elapsed={sw.ElapsedMilliseconds}ms tokenReused={tokenReused} status={statusCode}");
+                    }
+                    catch { }
+
+                    _ = Serialization.TryFromJson(json, out searchResult);
+
+                    try
+                    {
+                        bool successSample = searchResult != null && searchResult.Data != null && statusCode != 429;
+                        SearchConcurrencyController?.ReportSample(sw.ElapsedMilliseconds, successSample);
+                    }
+                    catch { }
+
+                    int postLockPendingConsume = 0;
+                    try
+                    {
+                        var codes = RecentSearchStatusCodes.ToArray();
+                        if (codes.Length > 0)
+                        {
+                            int count429 = codes.Count(c => c == 429);
+                            double frac = count429 / (double)codes.Length;
+                            if (count429 >= 3 && frac >= 0.05)
+                            {
+                                lock (BackoffSync)
+                                {
+                                    if (SearchBackoffLimit == 0 || DateTime.UtcNow >= SearchBackoffUntil)
+                                    {
+                                        int newLimit = Math.Max(1, CurrentSearchLimit / 2);
+                                        SearchBackoffLimit = newLimit;
+
+                                        int backoffSeconds = 30;
+                                        try
+                                        {
+                                            if (!string.IsNullOrEmpty(retryAfterHeader) && int.TryParse(retryAfterHeader, out int parsed))
+                                            {
+                                                backoffSeconds = Math.Max(1, parsed);
+                                            }
+                                        }
+                                        catch { }
+                                        SearchBackoffUntil = DateTime.UtcNow.AddSeconds(backoffSeconds);
+                                        Logger.Warn($"ApiSearch: detected elevated 429 rate ({count429}/{codes.Length}). Applying temporary search backoff -> limit={SearchBackoffLimit} until {SearchBackoffUntil:HH:mm:ss}");
+                                        try
+                                        {
+                                            int currentLimitSnapshot;
+                                            lock (SearchConcurrencySync)
+                                            {
+                                                currentLimitSnapshot = CurrentSearchLimit;
+                                            }
+                                            int diff = SearchBackoffLimit - currentLimitSnapshot;
+                                            if (diff > 0)
+                                            {
+                                                try { SearchSemaphore.Release(diff); } catch { }
+                                                lock (SearchConcurrencySync)
+                                                {
+                                                    CurrentSearchLimit = SearchBackoffLimit;
+                                                }
+                                            }
+                                            else if (diff < 0)
+                                            {
+                                                postLockPendingConsume = -diff;
+                                            }
+                                        }
+                                        catch { }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch { }
+
+                    try
+                    {
+                        if (postLockPendingConsume > 0)
+                        {
+                            int backoffSnapshot;
+                            lock (BackoffSync)
+                            {
+                                backoffSnapshot = SearchBackoffLimit;
+                            }
+
+                            await AdjustSemaphoreLimit(SearchSemaphore, () => CurrentSearchLimit, l => CurrentSearchLimit = l, backoffSnapshot, SearchConcurrencySync, "ApiSearch+PostBackoff");
+                        }
+                    }
+                    catch { }
+
+                    try
+                    {
+                        if (searchResult != null)
+                        {
+                            SearchCache.TryAdd(cacheKey, searchResult);
+                        }
+                    }
+                    catch { }
+
+                    return searchResult;
+                }
+                finally
+                {
+                    if (acquired)
+                    {
+                        try
+                        {
+                            SearchSemaphore.Release();
+                            LogDebugVerbose($"ApiSearch: released search semaphore for '{name}'");
+                        }
+                        catch { }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Opens a selection window for the user to choose the correct game data.
+        /// </summary>
+        /// <param name="game">The Playnite game object.</param>
+        /// <param name="data">Optional list of search results.</param>
+        /// <returns>Returns a <see cref="GameHowLongToBeat"/> object if a selection is made, otherwise null.</returns>
+        public GameHowLongToBeat SearchData(Game game, List<HltbDataUser> data = null)
+        {
+            Common.LogDebug(true, $"Search data for {game.Name}");
+            if (API.Instance.ApplicationInfo.Mode == ApplicationMode.Desktop)
+            {
+                HowLongToBeatSelect ViewExtension = null;
+                _ = Application.Current.Dispatcher.BeginInvoke((Action)delegate
+                {
+                    ViewExtension = new HowLongToBeatSelect(game, data);
+                    Window windowExtension = PlayniteUiHelper.CreateExtensionWindow(ResourceProvider.GetString("LOCSelection") + " - " + game.Name + " - " + (game.Source?.Name ?? "Playnite"), ViewExtension);
+                    _ = windowExtension.ShowDialog();
+                }).Wait();
+
+                if (ViewExtension.GameHowLongToBeat?.Items.Count > 0)
+                {
+                    return ViewExtension.GameHowLongToBeat;
+                }
+            }
+            return null;
+        }
+
+        public HltbDataUser SearchDataAuto(string gameName, string platform = "")
+        {
+            string traceId = null;
+            try
+            {
+                if (string.IsNullOrEmpty(gameName))
+                {
+                    return null;
+                }
+
+                // Apply manual aliases (exact normalized match) early so all subsequent matching uses the aliased title.
+                try
+                {
+                    var settings = PluginDatabase?.PluginSettings?.Settings;
+                    var userDataPath = PluginDatabase?.Plugin?.GetPluginUserDataPath();
+                    var aliased = GameNameAliases.ApplyAlias(gameName, settings, userDataPath);
+                    if (!string.IsNullOrEmpty(aliased) && !aliased.IsEqual(gameName))
+                    {
+                        LogDebugVerbose($"HLTB aliases: '{SafeStr(gameName)}' -> '{SafeStr(aliased)}'");
+                        gameName = aliased;
+                    }
+                }
+                catch { }
+
+                traceId = Guid.NewGuid().ToString("N").Substring(0, 8);
+
+                var hltbSettings = PluginDatabase?.PluginSettings?.Settings;
+
+                if (IsVerboseLoggingEnabled)
+                {
+                    try
+                    {
+                        Logger.Debug($"SearchDataAuto[{traceId}]: start name='{SafeStr(gameName)}' platform='{SafeStr(platform)}' UseMatchValue={hltbSettings?.UseMatchValue} MatchValue={hltbSettings?.MatchValue}");
+                    }
+                    catch { }
+                }
+
+                List<HltbSearch> results = null;
+                bool gotResults = false;
+                try
+                {
+                    // 1) First pass: fast search (no details fetch)
+                    gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 15000, Logger);
+                    if (!gotResults)
+                    {
+                        if (IsVerboseLoggingEnabled)
+                        {
+                            try { Logger.Warn($"SearchDataAuto[{traceId}]: SearchTwoMethod timed out after 15000ms; retrying once"); } catch { }
+                        }
+
+                        gotResults = TaskHelpers.TryRunSyncWithTimeout(() => SearchTwoMethod(gameName, platform), out results, 30000, Logger);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (IsVerboseLoggingEnabled)
+                    {
+                        try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
+                    }
+                    results = null;
+                }
+
+                if (!gotResults)
+                {
+                    if (IsVerboseLoggingEnabled)
+                    {
+                        try { Logger.Debug($"SearchDataAuto[{traceId}]: no results (timeout)"); } catch { }
+                    }
+                    return null;
+                }
+
+                if (results == null || results.Count == 0)
+                {
+                    if (IsVerboseLoggingEnabled)
+                    {
+                        try { Logger.Debug($"SearchDataAuto[{traceId}]: no results"); } catch { }
+                    }
+                    return null;
+                }
+
+                if (IsVerboseLoggingEnabled)
+                {
+                    try
+                    {
+                        Logger.Debug($"SearchDataAuto[{traceId}]: results count={results.Count}");
+                        int take = Math.Min(8, results.Count);
+                        for (int i = 0; i < take; i++)
+                        {
+                            var r = results[i];
+                            var d = r?.Data;
+                            long ttb = 0;
+                            bool hasAnyTime = false;
+                            try
+                            {
+                                ttb = d?.GameHltbData?.TimeToBeat ?? 0;
+                                hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
+                            }
+                            catch { }
+
+                            Logger.Debug($"SearchDataAuto[{traceId}]: candidate[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
+                        }
+                    }
+                    catch { }
+                }
+
+                try
+                {
+                    var nQuery = PlayniteTools.NormalizeGameName(gameName ?? string.Empty, true, true);
+                    if (!string.IsNullOrEmpty(nQuery))
+                    {
+                        var exact = results
+                            .Where(r => r?.Data != null)
+                            .Select(r => new { r.MatchPercent, Data = r.Data, Norm = PlayniteTools.NormalizeGameName(r.Data?.Name ?? string.Empty, true, true) })
+                            .Where(x => !string.IsNullOrEmpty(x.Norm) && x.Norm.IsEqual(nQuery))
+                            .OrderByDescending(x => x.MatchPercent)
+                            .FirstOrDefault();
+
+                        if (exact?.Data != null)
+                        {
+                            if (hltbSettings != null && hltbSettings.UseMatchValue && exact.MatchPercent < hltbSettings.MatchValue && exact.MatchPercent < 98)
+                            {
+                                if (IsVerboseLoggingEnabled)
+                                {
+                                    try { Logger.Debug($"SearchDataAuto[{traceId}]: exact normalized match rejected by MatchValue score={exact.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+                                }
+                                return null;
+                            }
+
+                            if (IsVerboseLoggingEnabled)
+                            {
+                                try { Logger.Debug($"SearchDataAuto[{traceId}]: selected exact normalized match id={SafeStr(exact.Data?.Id)} title='{SafeStr(exact.Data?.Name)}' score={exact.MatchPercent}"); } catch { }
+                            }
+
+                            return exact.Data;
+                        }
+                    }
+                }
+                catch { }
+
+                var best = results[0];
+                if (best?.Data == null)
+                {
+                    if (IsVerboseLoggingEnabled)
+                    {
+                        try { Logger.Debug($"SearchDataAuto[{traceId}]: best result had null data"); } catch { }
+                    }
+                    return null;
+                }
+
+                try
+                {
+                    if (hltbSettings != null && hltbSettings.UseMatchValue && best.MatchPercent < hltbSettings.MatchValue)
+                    {
+                        if (best.MatchPercent >= 98)
+                        {
+                            if (IsVerboseLoggingEnabled)
+                            {
+                                try { Logger.Debug($"SearchDataAuto[{traceId}]: best below MatchValue but accepted via near-perfect safety net score={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+                            }
+                            return best.Data;
+                        }
+
+                        if (IsVerboseLoggingEnabled)
+                        {
+                            try { Logger.Debug($"SearchDataAuto[{traceId}]: rejected by MatchValue bestScore={best.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+                        }
+                        return null;
+                    }
+                }
+                catch { }
+
+                // 2) Ambiguity handling: if multiple top results are close in score,
+                // fetch details for top candidates and prefer one that actually has times.
+                try
+                {
+                    if (results.Count > 1)
+                    {
+                        var second = results[1];
+                        bool ambiguous = false;
+                        try
+                        {
+                            ambiguous = (best.MatchPercent < 100 && second != null && (best.MatchPercent - second.MatchPercent) <= 3);
+                        }
+                        catch { }
+
+                        if (IsVerboseLoggingEnabled)
+                        {
+                            try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguity check best={best.MatchPercent} second={second?.MatchPercent} ambiguous={ambiguous}"); } catch { }
+                        }
+
+                        if (ambiguous)
+                        {
+                            List<HltbSearch> enriched = null;
+                            try
+                            {
+                                enriched = TaskHelpers.RunSyncWithTimeout(() => SearchTwoMethod(gameName, platform, includeExtendedTimes: true), 20000);
+                            }
+                            catch (Exception ex)
+                            {
+                                if (IsVerboseLoggingEnabled)
+                                {
+                                    try { Logger.Warn(ex, $"SearchDataAuto[{traceId}]: enrichment SearchTwoMethod threw for name='{SafeStr(gameName)}' platform='{SafeStr(platform)}'"); } catch { }
+                                }
+                                enriched = null;
+                            }
+
+                            if (enriched != null && enriched.Count > 0)
+                            {
+                                if (IsVerboseLoggingEnabled)
+                                {
+                                    try
+                                    {
+                                        Logger.Debug($"SearchDataAuto[{traceId}]: enriched count={enriched.Count}");
+                                        int take = Math.Min(8, enriched.Count);
+                                        for (int i = 0; i < take; i++)
+                                        {
+                                            var r = enriched[i];
+                                            var d = r?.Data;
+                                            long ttb = 0;
+                                            bool hasAnyTime = false;
+                                            try
+                                            {
+                                                ttb = d?.GameHltbData?.TimeToBeat ?? 0;
+                                                hasAnyTime = ttb > 0 || (d?.GameHltbData?.MainStoryClassic ?? 0) > 0 || (d?.GameHltbData?.SoloClassic ?? 0) > 0;
+                                            }
+                                            catch { }
+
+                                            Logger.Debug($"SearchDataAuto[{traceId}]: enriched[{i}] score={r?.MatchPercent} id={SafeStr(d?.Id)} title='{SafeStr(d?.Name)}' platform='{SafeStr(d?.Platform)}' hasTime={hasAnyTime} ttb={ttb} needsDetails={d?.NeedsDetails}");
+                                        }
+                                    }
+                                    catch { }
+                                }
+
+                                var withTimes = enriched
+                                    .Where(r => r?.Data?.GameHltbData != null)
+                                    .Where(r =>
+                                    {
+                                        try
+                                        {
+                                            return r.Data.GameHltbData.TimeToBeat > 0 || r.Data.GameHltbData.MainStoryClassic > 0 || r.Data.GameHltbData.MainExtraClassic > 0 || r.Data.GameHltbData.CompletionistClassic > 0 || r.Data.GameHltbData.SoloClassic > 0;
+                                        }
+                                        catch { return false; }
+                                    })
+                                    .OrderByDescending(r => r.MatchPercent)
+                                    .FirstOrDefault();
+
+                                if (withTimes?.Data != null)
+                                {
+                                    if (hltbSettings != null && hltbSettings.UseMatchValue && withTimes.MatchPercent < hltbSettings.MatchValue && withTimes.MatchPercent < 98)
+                                    {
+                                        if (IsVerboseLoggingEnabled)
+                                        {
+                                            try { Logger.Debug($"SearchDataAuto[{traceId}]: enriched withTimes rejected by MatchValue score={withTimes.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+                                        }
+                                        return null;
+                                    }
+
+                                    if (IsVerboseLoggingEnabled)
+                                    {
+                                        try { Logger.Debug($"SearchDataAuto[{traceId}]: selected enriched withTimes id={SafeStr(withTimes.Data?.Id)} title='{SafeStr(withTimes.Data?.Name)}' score={withTimes.MatchPercent}"); } catch { }
+                                    }
+                                    return withTimes.Data;
+                                }
+
+                                var bestEnriched = enriched[0];
+                                if (bestEnriched?.Data != null)
+                                {
+                                    if (hltbSettings != null && hltbSettings.UseMatchValue && bestEnriched.MatchPercent < hltbSettings.MatchValue && bestEnriched.MatchPercent < 98)
+                                    {
+                                        if (IsVerboseLoggingEnabled)
+                                        {
+                                            try { Logger.Debug($"SearchDataAuto[{traceId}]: bestEnriched rejected by MatchValue score={bestEnriched.MatchPercent} threshold={hltbSettings.MatchValue}"); } catch { }
+                                        }
+                                        return null;
+                                    }
+
+                                    if (IsVerboseLoggingEnabled)
+                                    {
+                                        try { Logger.Debug($"SearchDataAuto[{traceId}]: selected bestEnriched id={SafeStr(bestEnriched.Data?.Id)} title='{SafeStr(bestEnriched.Data?.Name)}' score={bestEnriched.MatchPercent}"); } catch { }
+                                    }
+                                    return bestEnriched.Data;
+                                }
+                            }
+
+                            if (best.MatchPercent >= 98)
+                            {
+                                if (IsVerboseLoggingEnabled)
+                                {
+                                    try { Logger.Debug($"SearchDataAuto[{traceId}]: ambiguous but fell back to near-perfect best score={best.MatchPercent} id={SafeStr(best.Data?.Id)}"); } catch { }
+                                }
+                                return best.Data;
+                            }
+                        }
+                    }
+                }
+                catch { }
+
+                if (IsVerboseLoggingEnabled)
+                {
+                    try { Logger.Debug($"SearchDataAuto[{traceId}]: selected best (default) id={SafeStr(best.Data?.Id)} title='{SafeStr(best.Data?.Name)}' score={best.MatchPercent}"); } catch { }
+                }
+
+                return best.Data;
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, true, PluginDatabase?.PluginName); } catch { }
+                return null;
+            }
+        }
+
+        #endregion
+
+        #region user account
+
+        /// <summary>
+        /// Checks if the user is currently logged in to HowLongToBeat (async).
+        /// </summary>
+        /// <returns>True if logged in, otherwise false.</returns>
+        public async Task<bool> GetIsUserLoggedInAsync()
+        {
+            // Avoid getting stuck in a "logged out" state if this method is called before PluginDatabase is loaded.
+            // Use stored cookies directly to check the current session.
+            try
+            {
+                var now = DateTime.UtcNow;
+                if (lastLoginCheckResult != null)
+                {
+                    var ttl = lastLoginCheckResult == true ? TimeSpan.FromMinutes(10) : TimeSpan.FromMinutes(1);
+                    if (now - lastLoginCheckUtc < ttl)
+                    {
+                        return lastLoginCheckResult.Value;
+                    }
+                }
+
+                int userId = await GetUserId().ConfigureAwait(false);
+                UserId = userId;
+                IsConnected = userId != 0;
+
+                lastLoginCheckUtc = now;
+                lastLoginCheckResult = userId != 0;
+
+                if (IsVerboseLoggingEnabled)
+                {
+                    Logger.Debug($"HLTB Auth: GetIsUserLoggedInAsync userId={userId} IsConnected={IsConnected}");
+                }
+
+                return userId != 0;
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+                UserId = 0;
+                IsConnected = false;
+                lastLoginCheckUtc = DateTime.UtcNow;
+                lastLoginCheckResult = false;
+                return false;
+            }
+        }
+
+        public bool GetIsUserLoggedIn()
+        {
+            try
+            {
+                return Task.Run(() => GetIsUserLoggedInAsync()).Result;
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Initiates the login process for HowLongToBeat.
+        /// </summary>
+        public void Login()
+        {
+            // Use a DispatcherOperation so we can attach the Completed handler cleanly
+            System.Windows.Threading.DispatcherOperation op = null;
+
+            try
+            {
+                op = Application.Current.Dispatcher.BeginInvoke((Action)delegate
+                {
+                    Logger.Info("Login()");
+
+                    bool cookiesCaptured = false;
+
+                    WebViewSettings settings = new WebViewSettings
+                    {
+                        JavaScriptEnabled = true,
+                        WindowHeight = 670,
+                        WindowWidth = 490,
+                        UserAgent = Web.UserAgent
+                    };
+
+                    using (IWebView webView = API.Instance.WebViews.CreateView(settings))
+                    {
+                        webView.LoadingChanged += (s, e) =>
+                        {
+                            try
+                            {
+                                Common.LogDebug(true, $"NavigationChanged - {webView.GetCurrentAddress()}");
+
+                                if (!cookiesCaptured && webView.GetCurrentAddress().StartsWith(UrlBase + "/user/"))
+                                {
+                                    cookiesCaptured = true;
+                                    UserLogin = WebUtility.HtmlDecode(webView.GetCurrentAddress().Replace(UrlBase + "/user/", string.Empty));
+                                    IsConnected = true;
+
+                                    // Give the embedded WebView a moment to commit cookies.
+                                    FireAndForget(Task.Run(async () =>
+                                    {
+                                        try
+                                        {
+                                            await Task.Delay(1000).ConfigureAwait(false);
+                                        }
+                                        catch { }
+
+                                        try
+                                        {
+                                            await Application.Current.Dispatcher.InvokeAsync(() =>
+                                            {
+                                                try
+                                                {
+                                                    List<HttpCookie> cookies = CookiesTools.GetWebCookies(deleteCookies: false, webView: webView);
+                                                    bool saved = CookiesTools.SetStoredCookies(cookies);
+                                                    Logger.Info($"HLTB Auth: captured cookies from login webview count={cookies?.Count ?? 0} saved={saved}");
+                                                    LogCookieSummary("login captured", cookies);
+
+                                                    // Invalidate cached login check so next calls re-check if needed.
+                                                    lastLoginCheckResult = null;
+                                                    lastLoginCheckUtc = DateTime.MinValue;
+                                                }
+                                                catch ( Exception ex)
+                                                {
+                                                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                                                }
+                                                finally
+                                                {
+                                                    try { webView.Close(); } catch { }
+                                                }
+                                            });
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+                                            try
+                                            {
+                                                var closeOp = Application.Current.Dispatcher.BeginInvoke((Action)(() => { try { webView.Close(); } catch { } }));
+                                                try { FireAndForget(closeOp?.Task, "login close webview (BeginInvoke)"); } catch { }
+                                            }
+                                            catch { }
+                                        }
+                                    }), "login captured");
+
+                                    // (task is fire-and-forget intentionally)
+
+                                    return;
+                                }
+                            }
+                            catch { }
+                        };
+
+                        IsConnected = false;
+                        webView.Navigate(UrlLogOut);
+                        _ = webView.OpenDialog();
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+            }
+
+            try
+            {
+                if (op != null)
+                {
+                    op.Completed += (s, e) =>
+                    {
+                        try
+                        {
+                            if ((bool)IsConnected)
+                            {
+                                _ = Application.Current.Dispatcher?.BeginInvoke((Action)delegate
+                                {
+                                    try
+                                    {
+                                        PluginDatabase.PluginSettings.Settings.UserLogin = UserLogin;
+
+                                        PluginDatabase.Plugin.SavePluginSettings(PluginDatabase.PluginSettings.Settings);
+
+                                        FireAndForget(Task.Run(async () =>
+                                        {
+                                            try { UserId = await GetUserId().ConfigureAwait(false); } catch { }
+                                            try { PluginDatabase.RefreshUserData(); } catch { }
+                                        }), "post-login refresh");
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                                    }
+                                });
+                            }
+                        }
+                        catch { }
+                    };
+                }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Retrieves the user ID of the currently logged-in user.
+        /// </summary>
+        /// <returns>User ID as integer, or 0 if not logged in.</returns>
+        private async Task<int> GetUserId()
+        {
+            try
+            {
+                List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+                LogCookieSummary("GetUserId stored", cookies);
+
+                if (cookies == null || cookies.Count == 0)
+                {
+                    try { Logger.Info("HLTB Auth: no stored cookies available"); } catch { }
+                }
+                string response = await Web.DownloadPageText(UrlUser, cookies);
+                dynamic t = Serialization.FromJson<dynamic>(response);
+
+                int userId = response == "{}" ? 0 : t?.data[0]?.user_id ?? 0;
+                if (IsVerboseLoggingEnabled)
+                {
+                    Logger.Debug($"HLTB Auth: GetUserId responseLen={response?.Length ?? 0} userId={userId}");
+                }
+
+                return userId;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false);
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the list of games for the current user.
+        /// </summary>
+        /// <returns>Returns a <see cref="UserGamesList"/> object.</returns>
+        private async Task<UserGamesList> GetUserGamesList()
+        {
+            try
+            {
+                List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+
+                UserGamesListParam userGamesListParam = new UserGamesListParam { UserId = UserId };
+                string payload = Serialization.ToJson(userGamesListParam);
+
+                string json = await PostJson(string.Format(UrlUserGamesList, UserId), payload, cookies);
+                _ = Serialization.TryFromJson(json, out UserGamesList userGamesList);
+
+                return userGamesList;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Converts a <see cref="GamesList"/> entry to a <see cref="TitleList"/>.
+        /// </summary>
+        /// <param name="gamesList">The games list entry.</param>
+        /// <returns>Returns a <see cref="TitleList"/> object.</returns>
+        private TitleList GetTitleList(GamesList gamesList)
+        {
+            try
+            {
+                _ = DateTime.TryParse(gamesList.DateUpdated, out DateTime lastUpdate);
+                _ = DateTime.TryParse(gamesList.DateComplete, out DateTime completion);
+                _ = DateTime.TryParse(gamesList.DateStart, out DateTime dateStart);
+                DateTime? completionFinal = null;
+                if (completion != default)
+                {
+                    completionFinal = completion;
+                }
+
+                TitleList titleList = new TitleList
+                {
+                    UserGameId = gamesList.Id.ToString(),
+                    GameName = gamesList.CustomTitle,
+                    Platform = gamesList.Platform,
+                    Id = gamesList.GameId.ToString(),
+                    CurrentTime = gamesList.InvestedPro,
+                    IsReplay = gamesList.PlayCount == 2,
+                    IsRetired = gamesList.ListRetired == 1,
+                    Storefront = gamesList.PlayStorefront,
+                    StartDate = dateStart,
+                    LastUpdate = lastUpdate,
+                    Completion = completionFinal,
+                    HltbUserData = new HltbData
+                    {
+                        GameType = gamesList.GameType.IsEqual("game") ? GameType.Game : gamesList.GameType.IsEqual("multi") ? GameType.Multi : GameType.Compil,
+                        MainStoryClassic = gamesList.CompMain,
+                        MainExtraClassic = gamesList.CompPlus,
+                        CompletionistClassic = gamesList.Comp100,
+                        SoloClassic = 0,
+                        CoOpClassic = gamesList.InvestedCo,
+                        VsClassic = gamesList.InvestedMp
+                    },
+                    GameStatuses = new List<GameStatus>()
+                };
+
+                if (gamesList.ListBacklog == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Backlog });
+                }
+
+                if (gamesList.ListComp == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Completed });
+                }
+
+                if (gamesList.ListCustom == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.CustomTab });
+                }
+
+                if (gamesList.ListPlaying == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Playing });
+                }
+
+                if (gamesList.ListReplay == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Replays });
+                }
+
+                if (gamesList.ListRetired == 1)
+                {
+                    titleList.GameStatuses.Add(new GameStatus { Status = StatusType.Retired });
+                }
+
+                return titleList;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the edit data for a specific user game entry.
+        /// </summary>
+        /// <param name="gameName">The name of the game.</param>
+        /// <param name="userGameId">The user game ID.</param>
+        /// <returns>Returns an <see cref="EditData"/> object.</returns>
+        public async Task<EditData> GetEditData(string gameName, string userGameId)
+        {
+            Logger.Info($"GetEditData({gameName}, {userGameId})");
+            try
+            {
+                List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+
+                string response = await Web.DownloadStringData(string.Format(UrlPostDataEdit, userGameId), cookies);
+                if (string.IsNullOrEmpty(response) || !response.Contains("__NEXT_DATA__"))
+                {
+                    Logger.Warn($"No EditData for {gameName} - {userGameId}");
+                    return null;
+                }
+
+                string jsonData = Tools.GetJsonInString(response, @"<script[ ]?id=""__NEXT_DATA__""[ ]?type=""application/json"">");
+                _ = Serialization.TryFromJson(jsonData, out NEXT_DATA next_data, out Exception parseEx);
+                if (parseEx != null)
+                {
+                    Common.LogError(parseEx, false, false, PluginDatabase.PluginName);
+                }
+
+                return next_data?.Props?.PageProps?.EditData?.UserId != null
+                    ? next_data.Props.PageProps.EditData
+                    : throw new Exception($"No EditData find for {gameName} - {userGameId}");
+            }
+            catch (Exception ex)
+            {
+                if (IsFirst)
+                {
+                    IsFirst = false;
+                    return await GetEditData(gameName, userGameId);
+                }
+                else
+                {
+                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads user stats from the local file.
+        /// </summary>
+        /// <returns>Returns a <see cref="HltbUserStats"/> object.</returns>
+        public HltbUserStats LoadUserData()
+        {
+            string pathHltbUserStats = Path.Combine(PluginDatabase.Plugin.GetPluginUserDataPath(), "HltbUserStats.json");
+            HltbUserStats hltbDataUser = new HltbUserStats();
+
+            if (File.Exists(pathHltbUserStats))
+            {
+                try
+                {
+                    if (!Serialization.TryFromJsonFile(pathHltbUserStats, out hltbDataUser))
+                    {
+                        return new HltbUserStats();
+                    }
+                    hltbDataUser.TitlesList = hltbDataUser.TitlesList.Where(x => x != null).ToList();
+                }
+                catch (Exception ex)
+                {
+                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                }
+            }
+
+            return hltbDataUser;
+        }
+
+        /// <summary>
+        /// Retrieves the user data from HowLongToBeat (async).
+        /// </summary>
+        /// <returns>Returns a <see cref="HltbUserStats"/> object, or null if not logged in.</returns>
+        public async Task<HltbUserStats> GetUserDataAsync()
+        {
+            if (await GetIsUserLoggedInAsync().ConfigureAwait(false))
+            {
+                HltbUserStats hltbUserStats = new HltbUserStats
+                {
+                    Login = UserLogin.IsNullOrEmpty() ? PluginDatabase.Database.UserHltbData.Login : UserLogin,
+                    UserId = (UserId == 0) ? PluginDatabase.Database.UserHltbData.UserId : UserId,
+                    TitlesList = new List<TitleList>()
+                };
+
+                UserGamesList userGamesList = null;
+                try { userGamesList = await GetUserGamesList().ConfigureAwait(false); } catch { userGamesList = null; }
+                if (userGamesList == null)
+                {
+                    return null;
+                }
+
+                try
+                {
+                    userGamesList.Data.GamesList.ForEach(x =>
+                    {
+                        TitleList titleList = GetTitleList(x);
+                        hltbUserStats.TitlesList.Add(titleList);
+                    });
+                }
+                catch (Exception ex)
+                {
+                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                    return null;
+                }
+
+                return hltbUserStats;
+            }
+            else
+            {
+                API.Instance.Notifications.Add(new NotificationMessage(
+                    $"{PluginDatabase.PluginName}-Import-Error",
+                    PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
+                    NotificationType.Error,
+                    () => PluginDatabase.Plugin.OpenSettingsView()
+                ));
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Synchronous wrapper for backwards compatibility; runs async method on thread-pool.
+        /// </summary>
+        public HltbUserStats GetUserData()
+        {
+            try
+            {
+                var task = Task.Run(() => GetUserDataAsync());
+                if (!task.Wait(15000))
+                {
+                    try { Logger.Warn("GetUserData timed out"); } catch { }
+                    return null;
+                }
+                return task.Result;
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, false, PluginDatabase?.PluginName); } catch { }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Finds the existing user game ID for a given game ID (async).
+        /// </summary>
+        public async Task<string> FindIdExistingAsync(string gameId)
+        {
+            try
+            {
+                var ug = await GetUserGamesList().ConfigureAwait(false);
+                return ug?.Data?.GamesList?.Find(x => x.GameId.ToString().IsEqual(gameId))?.Id.ToString() ?? null;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Synchronous wrapper for backwards compatibility.
+        /// </summary>
+        public string FindIdExisting(string gameId)
+        {
+            try
+            {
+                var task = Task.Run(() => FindIdExistingAsync(gameId));
+                if (!task.Wait(15000))
+                {
+                    try { Logger.Warn($"FindIdExisting({gameId}) timed out"); } catch { }
+                    return null;
+                }
+                return task.Result;
+            }
+            catch (Exception ex)
+            {
+                try { Common.LogError(ex, false, true, PluginDatabase.PluginName); } catch { }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Synchronous helper: get TitleList for a specific game id from user data.
+        /// </summary>
+        public TitleList GetUserData(string gameId)
+        {
+            try
+            {
+                var task = Task.Run(() => GetUserDataAsync());
+                if (!task.Wait(15000))
+                {
+                    try { Logger.Warn($"GetUserData (sync) timed out"); } catch { }
+                    return null;
+                }
+                var userData = task.Result;
+                return userData?.TitlesList?.Find(x => x.Id == gameId);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        public bool EditIdExist(string userGameId)
+        {
+            try
+            {
+                var task = Task.Run(() => GetUserGamesList());
+                if (!task.Wait(15000))
+                {
+                    try { Logger.Warn($"EditIdExist({userGameId}) timed out"); } catch { }
+                    return false;
+                }
+                var ug = task.Result;
+                return ug?.Data?.GamesList?.Find(x => x.Id.ToString().IsEqual(userGameId))?.Id != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        #endregion
+
+
+        /// <summary>
+        /// Submits the current game data to the HowLongToBeat website.
+        /// </summary>
+        /// <param name="game">The Playnite game object.</param>
+        /// <param name="editData">The data to submit.</param>
+        /// <returns>True if submission is successful, otherwise false.</returns>
+        public async Task<bool> ApiSubmitData(Game game, EditData editData)
+        {
+            if (GetIsUserLoggedIn() && editData.UserId != 0 && editData.GameId != 0)
+            {
+                try
+                {
+                    List<HttpCookie> cookies = CookiesTools.GetStoredCookies();
+                    string payload = Serialization.ToJson(editData);
+                    List<KeyValuePair<string, string>> moreHeaders = new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")
+                    };
+                    string response = await PostJson(UrlPostData, payload, cookies);
+
+                    if (string.IsNullOrEmpty(response))
+                    {
+                        API.Instance.Notifications.Add(new NotificationMessage(
+                            $"{PluginDatabase.PluginName}-{game.Id}-Error",
+                            PluginDatabase.PluginName + Environment.NewLine + game.Name,
+                            NotificationType.Error
+                        ));
+                        Logger.Warn($"ApiSubmitData: empty response when posting data for game {game.Id}");
+                        return false;
+                    }
+
+                    try
+                    {
+                        var success = false;
+                        _ = Serialization.TryFromJson(response, out dynamic respObj);
+                        if (respObj != null)
+                        {
+                            try
+                            {
+                                if (respObj.error != null)
+                                {
+                                    string msg = string.Empty;
+                                    try { msg = respObj.error[0]?.ToString() ?? respObj.error.ToString(); } catch { msg = respObj.error.ToString(); }
+                                    API.Instance.Notifications.Add(new NotificationMessage(
+                                        $"{PluginDatabase.PluginName}-{game.Id}-Error",
+                                        PluginDatabase.PluginName + Environment.NewLine + game.Name + (msg.IsNullOrEmpty() ? string.Empty : Environment.NewLine + msg),
+                                        NotificationType.Error
+                                    ));
+                                    Logger.Warn($"ApiSubmitData error for game {game.Id}: {msg}");
+                                }
+                                else if (respObj.errors != null)
+                                {
+                                    string msg = respObj.errors.ToString();
+                                    API.Instance.Notifications.Add(new NotificationMessage(
+                                        $"{PluginDatabase.PluginName}-{game.Id}-Error",
+                                        PluginDatabase.PluginName + Environment.NewLine + game.Name + Environment.NewLine + msg,
+                                        NotificationType.Error
+                                    ));
+                                    Logger.Warn($"ApiSubmitData errors for game {game.Id}: {msg}");
+                                }
+                                else
+                                {
+                                    success = true;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Common.LogError(ex, false, false, PluginDatabase.PluginName);
+                            }
+                        }
+                        else
+                        {
+                            Logger.Debug("ApiSubmitData: non-JSON response received; treating as success");
+                            success = true;
+                        }
+
+                        if (success)
+                        {
+                            PluginDatabase.RefreshUserData(editData.GameId.ToString());
+                            return true;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                        return false;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                    return false;
+                }
+            }
+            else
+            {
+                API.Instance.Notifications.Add(new NotificationMessage(
+                    $"{PluginDatabase.PluginName}-DataUpdate-Error",
+                    PluginDatabase.PluginName + Environment.NewLine + ResourceProvider.GetString("LOCCommonNotLoggedIn"),
+                    NotificationType.Error,
+                    () => PluginDatabase.Plugin.OpenSettingsView()
+                ));
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Updates the stored cookies for the current user session.
+        /// </summary>
+        public void UpdatedCookies()
+        {
+            try
+            {
+                // Run wait off the UI thread, then invoke UI work when ready
+                FireAndForget(Task.Run(async () =>
+                {
+                    var sw = System.Diagnostics.Stopwatch.StartNew();
+                    const int maxWaitMs = 60000; // 60s max wait for database load
+                    while (!PluginDatabase.IsLoaded)
+                    {
+                        await Task.Delay(100).ConfigureAwait(false);
+                        if (sw.ElapsedMilliseconds > maxWaitMs)
+                        {
+                            try { if (IsVerboseLoggingEnabled) Logger.Warn("Timeout waiting for PluginDatabase.IsLoaded in UpdatedCookies"); } catch { }
+                            break;
+                        }
+                    }
+
+                    try
+                    {
+                        await Application.Current.Dispatcher.InvokeAsync(() =>
+                        {
+                            try
+                            {
+                                if (PluginDatabase.Database.UserHltbData?.UserId != null && PluginDatabase.Database.UserHltbData.UserId != 0)
+                                {
+                                    Logger.Info($"Refresh HowLongToBeat user cookies");
+                                    List<HttpCookie> cookies = CookiesTools.GetNewWebCookies(new List<string> { UrlBase, UrlUser }, true);
+                                    _ = CookiesTools.SetStoredCookies(cookies);
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                            }
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                    }
+                }), "UpdatedCookies");
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+            }
+        }
+
+        /// <summary>
+        /// Try to extract script src URLs using HtmlAgilityPack via reflection. Returns null on failure.
+        /// Reflection is used because HAP is an optional dependency for the host application.
+        /// </summary>
+        private List<string> ExtractScriptUrlsWithHap(string html)
+        {
+            if (!HapAvailable || HapDocType == null || string.IsNullOrEmpty(html))
+            {
+                return null;
+            }
+
+            try
+            {
+                // Create HtmlDocument instance
+                dynamic doc = Activator.CreateInstance(HapDocType);
+                var loadHtml = HapDocType.GetMethod("LoadHtml");
+                loadHtml.Invoke(doc, new object[] { html });
+
+                var documentNode = HapDocType.GetProperty("DocumentNode").GetValue(doc);
+                var selectNodes = documentNode.GetType().GetMethod("SelectNodes", new Type[] { typeof(string) });
+                var nodes = selectNodes.Invoke(documentNode, new object[] { "//script[@src]" }) as System.Collections.IEnumerable;
+                if (nodes == null) return new List<string>();
+
+                var urls = new List<string>();
+                foreach (var node in nodes)
+                {
+                    try
+                    {
+                        var attrsProp = node.GetType().GetProperty("Attributes");
+                        if (attrsProp == null) continue;
+                        var attrs = attrsProp.GetValue(node);
+                        if (attrs == null) continue;
+                        var getAttr = attrs.GetType().GetMethod("Get", new Type[] { typeof(string) });
+                        if (getAttr == null) continue;
+                        var srcAttr = getAttr.Invoke(attrs, new object[] { "src" });
+                        if (srcAttr != null)
+                        {
+                            var valProp = srcAttr.GetType().GetProperty("Value");
+                            var val = valProp != null ? valProp.GetValue(srcAttr) as string : null;
+                            if (!string.IsNullOrEmpty(val)) urls.Add(val);
+                        }
+                    }
+                    catch { /* ignore per-node errors */ }
+                }
+
+                return urls;
+            }
+            catch (Exception ex)
+            {
+                try { Logger.Warn(ex, "HLTB: HtmlAgilityPack reflection extraction failed"); } catch { }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Posts JSON payload to URL, optionally with cookies, and returns response string.
+        /// </summary>
+        private async Task<string> PostJson(string url, string payload, List<HttpCookie> cookies = null, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                HttpClientHandler handler = null;
+                if (cookies != null)
+                {
+                    try
+                    {
+                        var mi = typeof(CommonPluginsShared.Web).GetMethod("CreateCookiesContainer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+                        if (mi != null)
+                        {
+                            var container = mi.Invoke(null, new object[] { cookies }) as CookieContainer;
+                            handler = new HttpClientHandler { CookieContainer = container };
+                        }
+                    }
+                    catch { handler = new HttpClientHandler(); }
+                }
+
+                HttpClient client = null;
+                bool disposeClient = false;
+                try
+                {
+                    if (handler != null)
+                    {
+                        client = new HttpClient(handler)
+                        {
+                            Timeout = System.Threading.Timeout.InfiniteTimeSpan
+                        };
+                        disposeClient = true;
+                    }
+                    else
+                    {
+                        // Reuse the shared instance-level httpClient to avoid socket exhaustion
+                        client = httpClient ?? new HttpClient();
+                        disposeClient = false;
+                    }
+
+                    if (handler != null)
+                    {
+                        try { client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Web.UserAgent); } catch { }
+                        try { client.DefaultRequestHeaders.TryAddWithoutValidation("accept", "application/json, text/javascript, */*; q=0.01"); } catch { }
+                    }
+
+                    var content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
+                    using (var resp = await client.PostAsync(url, content, cancellationToken).ConfigureAwait(false))
+                    {
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            try { Logger.Warn($"HTTP {(int)resp.StatusCode} posting to {url}"); } catch { }
+                            return string.Empty;
+                        }
+
+                        return await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    }
+                }
+                finally
+                {
+                    if (disposeClient && client != null)
+                    {
+                        try { client.Dispose(); } catch { }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, $"Error posting to {url}");
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Posts JSON payload using shared HttpClient and returns tuple (responseBody, statusCode, retryAfterHeader).
+        /// This is a local replacement for CommonPluginsShared.Web.PostJsonWithSharedClientWithStatus when the submodule isn't available.
+        /// </summary>
+        private async Task<(string body, int status, string retry)> PostJsonWithSharedClientWithStatus(string url, string payload, List<HttpHeader> headers = null, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using (var request = new HttpRequestMessage(HttpMethod.Post, url))
+                {
+                    request.Content = new StringContent(payload ?? string.Empty, Encoding.UTF8, "application/json");
+
+                    if (headers != null)
+                    {
+                        foreach (var h in headers)
+                        {
+                            try
+                            {
+                                // Try to add to request headers; if invalid, try content headers
+                                if (!request.Headers.TryAddWithoutValidation(h.Key, h.Value))
+                                {
+                                    try { request.Content?.Headers.TryAddWithoutValidation(h.Key, h.Value); } catch { }
+                                }
+                            }
+                            catch { }
+                        }
+                    }
+
+                    using (var resp = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
+                    {
+                        int status = (int)resp.StatusCode;
+                        string retry = null;
+                        try
+                        {
+                            if (resp.Headers.TryGetValues("Retry-After", out var vals))
+                            {
+                                retry = vals.FirstOrDefault();
+                            }
+                        }
+                        catch { }
+
+                        string body = string.Empty;
+                        try { body = await resp.Content.ReadAsStringAsync().ConfigureAwait(false); } catch { body = string.Empty; }
+
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            try { Logger.Warn($"HTTP {status} posting to {url}"); } catch { }
+                        }
+
+                        return (body, status, retry);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, $"Error posting to {url}");
+                return (string.Empty, 0, (string)null);
+            }
+        }
+        private static readonly Regex _scriptSrcRegex = new Regex("<script[^>]*src=[\\\"']([^\\\"']+)[\\\"'][^>]*>", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        private static Regex MyRegex() => _scriptSrcRegex;
+    }
 }

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -1046,8 +1046,24 @@ namespace HowLongToBeat.Services
                     if (gameHowLongToBeat != null && (!gameHowLongToBeat.GetData()?.IsVndb ?? false))
                     {
                         TimeSpan time = TimeSpan.FromSeconds(game.Playtime);
-                        string platformName = HltbPlatform.PC.GetDescription();
+                        HltbDataUser hltbDataUser = gameHowLongToBeat.GetData();
+						string platformName = HltbPlatform.PC.GetDescription();
                         string storefrontName = string.Empty;
+
+						#region Validate Id
+
+						if(string.IsNullOrWhiteSpace(hltbDataUser.Id))
+						{
+							Logger.Warn($"Cannot submit data for a game without HLTB ID ({game.Name})");
+							API.Instance.Notifications.Add(new NotificationMessage(
+								$"{PluginName}-NoHltbId-Error-{new Guid()}",
+								PluginName + Environment.NewLine + string.Format(ResourceProvider.GetString("LOCHowLongToBeatErrorNoHltbId"), game.Name),
+								NotificationType.Error
+							));
+							return false;
+						}
+
+						#endregion
 
                         #region Search platform
 
@@ -1098,7 +1114,6 @@ namespace HowLongToBeat.Services
 
                         #region Get current data from HowLongToBeat
 
-                        HltbDataUser hltbDataUser = gameHowLongToBeat.GetData();
                         TitleList HltbData = GetUserHltbDataCurrent(hltbDataUser.Id, gameHowLongToBeat.UserGameId);
                         EditData editData = new EditData();
                         string submissionId = "0";

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -1056,7 +1056,7 @@ namespace HowLongToBeat.Services
 						{
 							Logger.Warn($"Cannot submit data for a game without HLTB ID ({game.Name})");
 							API.Instance.Notifications.Add(new NotificationMessage(
-								$"{PluginName}-NoHltbId-Error-{new Guid()}",
+								$"{PluginName}-NoHltbId-Error-{Guid.NewGuid()}",
 								PluginName + Environment.NewLine + string.Format(ResourceProvider.GetString("LOCHowLongToBeatErrorNoHltbId"), game.Name),
 								NotificationType.Error
 							));
@@ -1072,7 +1072,7 @@ namespace HowLongToBeat.Services
                         {
                             Logger.Warn($"Cannot submit data for a game without platform ({game.Name})");
                             API.Instance.Notifications.Add(new NotificationMessage(
-                               $"{PluginName}-NoPlatform-Error-{new Guid()}",
+                               $"{PluginName}-NoPlatform-Error-{Guid.NewGuid()}",
                                PluginName + Environment.NewLine + string.Format(ResourceProvider.GetString("LOCHowLongToBeatErrorNoPlatform"), game.Name),
                                NotificationType.Error,
                                () => Plugin.OpenSettingsView()
@@ -1089,7 +1089,7 @@ namespace HowLongToBeat.Services
                         {
                             Logger.Warn($"No platform find for {game.Name} - Default \"PC\" used");
                             API.Instance.Notifications.Add(new NotificationMessage(
-                               $"{PluginName}-NoPlatformDefined-Error-{new Guid()}",
+                               $"{PluginName}-NoPlatformDefined-Error-{Guid.NewGuid()}",
                                PluginName + Environment.NewLine + string.Format(ResourceProvider.GetString("LOCHowLongToBeatErrorNoPlatformDefaultUsed"), platform.Name, game.Name),
                                NotificationType.Error,
                                () => Plugin.OpenSettingsView()

--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -43,10 +43,10 @@
         <TabControl x:Name="PART_Tabs" DockPanel.Dock="Top" SelectionChanged="PART_Tabs_SelectionChanged">
 
             <TabItem x:Name="PART_TabSearch" Header="{DynamicResource LOCHltbTabSearch}">
-                <Grid x:Name="PART_SearchPane">
+            <DockPanel x:Name="PART_SearchPane" LastChildFill="True">
 
                     <!-- Name -->
-                    <Grid Margin="0,10,0,0" DockPanel.Dock="Bottom">
+                    <Grid Margin="0,0,0,10" DockPanel.Dock="Top">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="6"/>
@@ -54,12 +54,12 @@
                         </Grid.ColumnDefinitions>
 
                         <playnitecontrols:SearchBox Grid.Column="0" x:Name="SearchElement" KeyUp="SearchElement_KeyUp"/>
-                        <Button Name="PART_BtSearch" Grid.Column="3" Content="{DynamicResource LOCSearchLabel}" Click="ButtonSearch_Click"
+                        <Button Name="PART_BtSearch" Grid.Column="2" Content="{DynamicResource LOCSearchLabel}" Click="ButtonSearch_Click"
                                         IsEnabled="{Binding ElementName=SearchElement, Path=Text, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"/>
                     </Grid>
 
                     <!-- Platforms -->
-                    <Grid Margin="0,10,0,0" DockPanel.Dock="Bottom">
+                    <Grid Margin="0,0,0,10" DockPanel.Dock="Top">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="auto"/>
                             <ColumnDefinition Width="6"/>
@@ -486,9 +486,9 @@
                                 </Grid>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
-                    </ListBox>
-                </Grid>
-            </TabItem>
+                         </ListBox>
+                    </DockPanel>
+                    </TabItem>
 
             <TabItem x:Name="PART_TabManual" Header="{DynamicResource LOCHltbTabManual}">
                 <Grid x:Name="PART_ManualPane"

--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -908,6 +908,7 @@
                             <RowDefinition Height="8"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
                         <!-- Column headers -->
@@ -965,6 +966,15 @@
                                                            Foreground="{DynamicResource CardForegroundBrush}"/>
                         <TextBox x:Name="PART_ManualCoOpH" Grid.Column="1" Grid.Row="7" Margin="0,3,6,3" Text="0"/>
                         <TextBox x:Name="PART_ManualCoOpM" Grid.Column="3" Grid.Row="7" Margin="0,3,0,3" Text="0"/>
+
+                        <!-- Optional HLTB ID -->
+                        <TextBlock Grid.Column="0" Grid.Row="8" VerticalAlignment="Center" Margin="0,6,0,0"
+                                   Text="{DynamicResource LOCHltbManualEntryHltbId}"
+                                   Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBox x:Name="PART_ManualHltbId"
+                                 Grid.Column="1" Grid.Row="8" Grid.ColumnSpan="3"
+                                 Margin="0,6,0,0"
+                                 ToolTip="{DynamicResource LOCHltbManualEntryHltbId}"/>
                     </Grid>
 
                     <!-- Open website -->

--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -1,19 +1,18 @@
 ﻿<UserControl x:Class="HowLongToBeat.Views.HowLongToBeatSelect"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:commonpluginsshared="clr-namespace:CommonPluginsShared"
-             xmlns:playnitecontrols="clr-namespace:CommonPluginsControls.PlayniteControls"
-             xmlns:converters="clr-namespace:CommonPlayniteShared.Converters"
-             xmlns:controls="clr-namespace:CommonPluginsControls.Controls"
-             xmlns:convertersshared="clr-namespace:CommonPluginsShared.Converters"
-             xmlns:hltm="clr-namespace:HowLongToBeat.Models"
-             xmlns:hlte="clr-namespace:HowLongToBeat.Models.Enumerations"
-             xmlns:hltb="clr-namespace:HowLongToBeat.Behaviors"
-             xmlns:controls1="clr-namespace:CommonPluginsShared.Controls"
-             mc:Ignorable="d"
-             Width="700">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:commonpluginsshared="clr-namespace:CommonPluginsShared"
+    xmlns:playnitecontrols="clr-namespace:CommonPluginsControls.PlayniteControls"
+    xmlns:converters="clr-namespace:CommonPlayniteShared.Converters"
+    xmlns:controls="clr-namespace:CommonPluginsControls.Controls"
+    xmlns:convertersshared="clr-namespace:CommonPluginsShared.Converters"
+    xmlns:hltm="clr-namespace:HowLongToBeat.Models"
+    xmlns:hlte="clr-namespace:HowLongToBeat.Models.Enumerations"
+    xmlns:hltb="clr-namespace:HowLongToBeat.Behaviors"
+    xmlns:controls1="clr-namespace:CommonPluginsShared.Controls"
+    mc:Ignorable="d" Width="700">
 
         <UserControl.Resources>
                 <convertersshared:VisibilityZeroConverter x:Key="VisibilityZeroConverter"/>
@@ -21,452 +20,74 @@
                 <converters:StringNullOrEmptyToBoolConverter x:Key="StringNullOrEmptyToBoolConverter"/>
                 <converters:StringNullOrEmptyToVisibilityConverter x:Key="StringNullOrEmptyToVisibilityConverter"/>
 
-                <!-- Color resources for dark cards and buttons (theme-overridable via DynamicResource keys) -->
-                <SolidColorBrush x:Key="CardBackgroundBrush"
-                                 Color="#2E2F33"/>
-                <SolidColorBrush x:Key="CardForegroundBrush"
-                                 Color="#FFFFFF"/>
-                <SolidColorBrush x:Key="CardBorderBrush"
-                                 Color="#444"/>
-
-                <SolidColorBrush x:Key="PrimaryButtonBackgroundBrush"
-                                 Color="#5A9BD5"/>
-                <SolidColorBrush x:Key="PrimaryButtonHoverBrush"
-                                 Color="#4B89C6"/>
-                <SolidColorBrush x:Key="PrimaryButtonForegroundBrush"
-                                 Color="#FFFFFF"/>
-
-                <!-- Card-like item appearance -->
-                <Style x:Key="ItemBorderStyle"
-                       TargetType="Border">
-                        <Setter Property="Background"
-                                Value="{DynamicResource CardBackgroundBrush}"/>
-                        <Setter Property="CornerRadius"
-                                Value="8"/>
-                        <Setter Property="Padding"
-                                Value="8"/>
-                        <Setter Property="Margin"
-                                Value="6"/>
-                        <Setter Property="SnapsToDevicePixels"
-                                Value="True"/>
-                        <Setter Property="BorderBrush"
-                                Value="{DynamicResource CardBorderBrush}"/>
-                        <Setter Property="BorderThickness"
-                                Value="1"/>
-                        <!-- Removed default DropShadowEffect for performance; only use light shadows on hover/selection -->
-                        <Setter Property="RenderTransform">
-                                <Setter.Value>
-                                        <TranslateTransform Y="0"/>
-                                </Setter.Value>
-                        </Setter>
-                        <Style.Triggers>
-                                <!-- When the containing ListBoxItem is hovered, highlight only the card (light effect) -->
-                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ListBoxItem}}"
-                                             Value="True">
-                                        <Setter Property="BorderBrush"
-                                                Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
-                                        <Setter Property="BorderThickness"
-                                                Value="1.5"/>
-                                        <Setter Property="Effect">
-                                                <Setter.Value>
-                                                        <!-- lighter, less expensive shadow -->
-                                                        <DropShadowEffect Color="#22000000"
-                                                                          BlurRadius="8"
-                                                                          ShadowDepth="2"
-                                                                          Opacity="0.45"/>
-                                                </Setter.Value>
-                                        </Setter>
-                                        <Setter Property="RenderTransform">
-                                                <Setter.Value>
-                                                        <TranslateTransform Y="-2"/>
-                                                </Setter.Value>
-                                        </Setter>
-                                </DataTrigger>
-
-                                <!-- When the containing ListBoxItem is selected, apply a subtle card-only highlight -->
-                                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}"
-                                             Value="True">
-                                        <Setter Property="BorderBrush"
-                                                Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
-                                        <Setter Property="BorderThickness"
-                                                Value="1.5"/>
-                                        <Setter Property="Background"
-                                                Value="#33363A"/>
-                                        <Setter Property="Effect">
-                                                <Setter.Value>
-                                                        <!-- slightly stronger but still moderate shadow -->
-                                                        <DropShadowEffect Color="#33000000"
-                                                                          BlurRadius="10"
-                                                                          ShadowDepth="3"
-                                                                          Opacity="0.6"/>
-                                                </Setter.Value>
-                                        </Setter>
-                                        <Setter Property="RenderTransform">
-                                                <Setter.Value>
-                                                        <TranslateTransform Y="-3"/>
-                                                </Setter.Value>
-                                        </Setter>
-                                </DataTrigger>
-
-                                <!-- When the containing ListBoxItem has keyboard focus, show a focus indicator similar to hover -->
-                                <DataTrigger Binding="{Binding IsKeyboardFocusWithin, RelativeSource={RelativeSource AncestorType=ListBoxItem}}"
-                                             Value="True">
-                                        <Setter Property="BorderBrush"
-                                                Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
-                                        <Setter Property="BorderThickness"
-                                                Value="1.5"/>
-                                        <Setter Property="Effect">
-                                                <Setter.Value>
-                                                        <DropShadowEffect Color="#22000000"
-                                                                          BlurRadius="8"
-                                                                          ShadowDepth="2"
-                                                                          Opacity="0.5"/>
-                                                </Setter.Value>
-                                        </Setter>
-                                        <Setter Property="RenderTransform">
-                                                <Setter.Value>
-                                                        <TranslateTransform Y="-2"/>
-                                                </Setter.Value>
-                                        </Setter>
-                                </DataTrigger>
-                        </Style.Triggers>
-                </Style>
-
-                <!-- Tab active / inactive styles -->
-                <Style x:Key="TabActiveStyle"
-                       TargetType="Button">
-                        <Setter Property="Background"
-                                Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource PrimaryButtonForegroundBrush}"/>
-                        <Setter Property="FontWeight"
-                                Value="Bold"/>
-                        <Setter Property="Padding"
-                                Value="18,8"/>
-                        <Setter Property="Margin"
-                                Value="0"/>
-                        <Setter Property="BorderThickness"
-                                Value="0"/>
-                        <Setter Property="Template">
-                                <Setter.Value>
-                                        <ControlTemplate TargetType="Button">
-                                                <Border Background="{TemplateBinding Background}"
-                                                        BorderThickness="0,0,0,3"
-                                                        BorderBrush="{DynamicResource PrimaryButtonForegroundBrush}"
-                                                        Padding="{TemplateBinding Padding}">
-                                                        <ContentPresenter HorizontalAlignment="Center"
-                                                                          VerticalAlignment="Center"/>
-                                                </Border>
-                                        </ControlTemplate>
-                                </Setter.Value>
-                        </Setter>
-                </Style>
-
-                <Style x:Key="TabInactiveStyle"
-                       TargetType="Button">
-                        <Setter Property="Background"
-                                Value="Transparent"/>
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource CardForegroundBrush}"/>
-                        <Setter Property="FontWeight"
-                                Value="Normal"/>
-                        <Setter Property="Padding"
-                                Value="18,8"/>
-                        <Setter Property="Margin"
-                                Value="0"/>
-                        <Setter Property="Opacity"
-                                Value="0.55"/>
-                        <Setter Property="BorderThickness"
-                                Value="0"/>
-                        <Setter Property="Template">
-                                <Setter.Value>
-                                        <ControlTemplate TargetType="Button">
-                                                <Border Background="{TemplateBinding Background}"
-                                                        BorderThickness="0,0,0,2"
-                                                        BorderBrush="{DynamicResource CardBorderBrush}"
-                                                        Padding="{TemplateBinding Padding}">
-                                                        <ContentPresenter HorizontalAlignment="Center"
-                                                                          VerticalAlignment="Center"/>
-                                                </Border>
-                                                <ControlTemplate.Triggers>
-                                                        <Trigger Property="IsMouseOver" Value="True">
-                                                                <Setter Property="Opacity" Value="0.85"/>
-                                                        </Trigger>
-                                                </ControlTemplate.Triggers>
-                                        </ControlTemplate>
-                                </Setter.Value>
-                        </Setter>
-                </Style>
-
-                <!-- Button look -->
-                <Style x:Key="PrimaryButtonStyle"
-                       TargetType="Button">
-                        <Setter Property="Background"
-                                Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
-                        <Setter Property="Foreground"
-                                Value="{DynamicResource PrimaryButtonForegroundBrush}"/>
-                        <Setter Property="Padding"
-                                Value="8,6"/>
-                        <Setter Property="Margin"
-                                Value="0"/>
-                        <Setter Property="MinWidth"
-                                Value="80"/>
-                        <Setter Property="FontWeight"
-                                Value="SemiBold"/>
-                        <Setter Property="BorderBrush"
-                                Value="#2E6A9C"/>
-                        <Setter Property="BorderThickness"
-                                Value="1"/>
-                        <Setter Property="RenderTransformOrigin"
-                                Value="0.5,0.5"/>
-                        <Setter Property="RenderTransform">
-                                <Setter.Value>
-                                        <TransformGroup>
-                                                <ScaleTransform ScaleX="1"
-                                                                ScaleY="1"/>
-                                                <TranslateTransform X="0"
-                                                                    Y="0"/>
-                                        </TransformGroup>
-                                </Setter.Value>
-                        </Setter>
-                        <Setter Property="Template">
-                                <Setter.Value>
-                                        <ControlTemplate TargetType="Button">
-                                                <Border Background="{TemplateBinding Background}"
-                                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                                        CornerRadius="4"
-                                                        Padding="{TemplateBinding Padding}">
-                                                        <ContentPresenter HorizontalAlignment="Center"
-                                                                          VerticalAlignment="Center"/>
-                                                </Border>
-                                                <ControlTemplate.Triggers>
-                                                        <Trigger Property="IsMouseOver"
-                                                                 Value="True">
-                                                                <Setter Property="Background"
-                                                                        Value="{DynamicResource PrimaryButtonHoverBrush}"/>
-                                                                <Setter Property="BorderBrush"
-                                                                        Value="#1F6EA0"/>
-                                                                <Setter Property="Effect">
-                                                                        <Setter.Value>
-                                                                                <DropShadowEffect Color="#22000000"
-                                                                                                  BlurRadius="10"
-                                                                                                  ShadowDepth="2"
-                                                                                                  Opacity="0.6"/>
-                                                                        </Setter.Value>
-                                                                </Setter>
-                                                                <Setter Property="RenderTransform">
-                                                                        <Setter.Value>
-                                                                                <TransformGroup>
-                                                                                        <ScaleTransform ScaleX="1.02"
-                                                                                                        ScaleY="1.02"/>
-                                                                                        <TranslateTransform X="0"
-                                                                                                            Y="-1"/>
-                                                                                </TransformGroup>
-                                                                        </Setter.Value>
-                                                                </Setter>
-                                                        </Trigger>
-
-                                                        <Trigger Property="IsPressed"
-                                                                 Value="True">
-                                                                <Setter Property="RenderTransform">
-                                                                        <Setter.Value>
-                                                                                <TransformGroup>
-                                                                                        <ScaleTransform ScaleX="0.99"
-                                                                                                        ScaleY="0.99"/>
-                                                                                        <TranslateTransform X="0"
-                                                                                                            Y="0"/>
-                                                                                </TransformGroup>
-                                                                        </Setter.Value>
-                                                                </Setter>
-                                                                <Setter Property="Effect">
-                                                                        <Setter.Value>
-                                                                                <DropShadowEffect Color="#18000000"
-                                                                                                  BlurRadius="6"
-                                                                                                  ShadowDepth="1"
-                                                                                                  Opacity="0.5"/>
-                                                                        </Setter.Value>
-                                                                </Setter>
-                                                        </Trigger>
-
-                                                        <Trigger Property="IsEnabled"
-                                                                 Value="False">
-                                                                <Setter Property="Opacity"
-                                                                        Value="0.6"/>
-                                                        </Trigger>
-                                                </ControlTemplate.Triggers>
-                                        </ControlTemplate>
-                                </Setter.Value>
-                        </Setter>
-                </Style>
-
-                <!-- Make listbox items stretch to full width and remove default highlighting -->
-                <Style x:Key="ListBoxItemContainerStyle"
-                       TargetType="ListBoxItem">
-                         <Setter Property="Padding"
-                                 Value="0"/>
-                         <Setter Property="Margin"
-                                 Value="0"/>
-                         <Setter Property="HorizontalContentAlignment"
-                                 Value="Stretch"/>
-                         <Setter Property="VerticalContentAlignment"
-                                 Value="Top"/>
-                         <Setter Property="Background"
-                                 Value="Transparent"/>
-                         <!-- Keep items tabbable so keyboard users can navigate. Avoid removing focus visuals; use the ItemBorderStyle focus trigger above. -->
-                         <Setter Property="IsTabStop" Value="True"/>
-                         <Setter Property="Template">
-                                 <Setter.Value>
-                                         <ControlTemplate TargetType="ListBoxItem">
-                                                 <ContentPresenter/>
-                                         </ControlTemplate>
-                                 </Setter.Value>
-                         </Setter>
-                         <EventSetter Event="PreviewMouseLeftButtonDown"
-                                      Handler="ListBoxItem_PreviewMouseLeftButtonDown"/>
-                         <Style.Triggers>
-                                 <Trigger Property="IsMouseOver"
-                                          Value="True">
-                                         <Setter Property="Cursor"
-                                                 Value="Hand"/>
-                                 </Trigger>
-                         </Style.Triggers>
-                 </Style>
-        </UserControl.Resources>
+                </UserControl.Resources>
 
         <DockPanel LastChildFill="True"
                    Margin="10"
                    Name="SelectableContent">
                 <!-- Actions -->
-                <Grid Margin="0,10,0,0"
-                      DockPanel.Dock="Bottom">
+                <Grid Margin="0,10,0,0" DockPanel.Dock="Bottom">
                         <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="Auto"/>
                                 <ColumnDefinition Width="6"/>
-                                <ColumnDefinition Width="120"/>
+                                <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
-                        <Button Name="ButtonSelect"
-                                IsEnabled="False"
-                                Grid.Column="1"
-                                Content="{DynamicResource LOCSelect}"
-                                VerticalAlignment="Center"
-                                Click="ButtonSelect_Click"
-                                Style="{StaticResource PrimaryButtonStyle}"/>
-                        <Button Name="ButtonConfirmManual"
-                                Visibility="Collapsed"
-                                Grid.Column="1"
-                                Content="{DynamicResource LOCHltbManualEntryConfirm}"
-                                VerticalAlignment="Center"
-                                Click="ButtonAddManual_Click"
-                                Style="{StaticResource PrimaryButtonStyle}"/>
-                        <Button Grid.Column="3"
-                                Content="{DynamicResource LOCCancelLabel}"
-                                VerticalAlignment="Center"
-                                Click="ButtonCancel_Click"
-                                Style="{StaticResource PrimaryButtonStyle}"/>
+                        <Button Name="ButtonSelect" IsEnabled="False" Grid.Column="1" Content="{DynamicResource LOCSelect}" VerticalAlignment="Center" Click="ButtonSelect_Click"/>
+                        <Button Name="ButtonConfirmManual" Visibility="Collapsed" Grid.Column="1" Content="{DynamicResource LOCHltbManualEntryConfirm}" VerticalAlignment="Center" Click="ButtonAddManual_Click"/>
+                        <Button Grid.Column="3" Content="{DynamicResource LOCCancelLabel}" VerticalAlignment="Center" Click="ButtonCancel_Click"/>
                 </Grid>
 
-                <!-- Mode tab bar -->
-                <Border DockPanel.Dock="Top"
-                        BorderBrush="{DynamicResource CardBorderBrush}"
-                        BorderThickness="0,0,0,1"
-                        Margin="0,0,0,10">
-                        <StackPanel Orientation="Horizontal">
-                                <Button x:Name="PART_TabSearch"
-                                        Content="{DynamicResource LOCHltbTabSearch}"
-                                        Click="TabSearch_Click"
-                                        Style="{StaticResource TabActiveStyle}"/>
-                                <Button x:Name="PART_TabManual"
-                                        Content="{DynamicResource LOCHltbTabManual}"
-                                        Click="TabManual_Click"
-                                        Style="{StaticResource TabInactiveStyle}"/>
-                        </StackPanel>
-                </Border>
+                <!-- Mode tab control -->
+        <TabControl x:Name="PART_Tabs" DockPanel.Dock="Top" SelectionChanged="PART_Tabs_SelectionChanged">
 
-                <!-- Search pane -->
-                <Grid x:Name="PART_SearchPane"
-                      DockPanel.Dock="Top">
-                        <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
+            <TabItem x:Name="PART_TabSearch" Header="{DynamicResource LOCHltbTabSearch}">
+                <Grid x:Name="PART_SearchPane">
 
-                        <!-- Search controls: search box + platform -->
-                        <Grid Grid.Row="0" Margin="0,0,0,10">
-                                <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="6"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
+                    <!-- Name -->
+                    <Grid Margin="0,10,0,0" DockPanel.Dock="Bottom">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="150"/>
+                        </Grid.ColumnDefinitions>
 
-                                <Grid Grid.Column="0">
-                                        <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*"/>
-                                                <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
+                        <playnitecontrols:SearchBox Grid.Column="0" x:Name="SearchElement" KeyUp="SearchElement_KeyUp"/>
+                        <Button Name="PART_BtSearch" Grid.Column="3" Content="{DynamicResource LOCSearchLabel}" Click="ButtonSearch_Click"
+                                        IsEnabled="{Binding ElementName=SearchElement, Path=Text, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"/>
+                    </Grid>
 
-                                        <playnitecontrols:SearchBox x:Name="SearchElement"
-                                                                    KeyUp="SearchElement_KeyUp"
-                                                                    Grid.Column="0"
-                                                                    HorizontalAlignment="Stretch"
-                                                                    MinWidth="200"
-                                                                    MaxWidth="420"/>
+                    <!-- Platforms -->
+                    <Grid Margin="0,10,0,0" DockPanel.Dock="Bottom">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="auto"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="6"/>
+                            <ColumnDefinition Width="150"/>
+                        </Grid.ColumnDefinitions>
 
-                                        <Button Name="PART_BtSearch"
-                                                Grid.Column="1"
-                                                Content="{DynamicResource LOCSearchLabel}"
-                                                Click="ButtonSearch_Click"
-                                                Margin="6,0,0,0"
-                                                IsEnabled="{Binding ElementName=SearchElement, Path=Text, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"
-                                                Style="{StaticResource PrimaryButtonStyle}"/>
-                                </Grid>
+                        <TextBlock Grid.Column="0" Text="{DynamicResource LOCPlatformsTitle}" Style="{StaticResource BaseTextBlockStyle}" VerticalAlignment="Center"/>
+                        <controls:ComboBoxRemovable x:Name="PART_SelectPlatform" Grid.Column="2" VerticalAlignment="Center"
+                                                            IsEditable="True" TextSearch.TextPath="DisplayText"
+                                                            IsEnabled="{Binding ElementName=PART_Vndb, Path=IsChecked, Converter={StaticResource InvertedBoolenConverter}}"
+                                                            IsTextSearchCaseSensitive="False" StaysOpenOnEdit="True"
+                                                            hltb:SelectorBehaviors.EnumSource="{x:Type hlte:HltbPlatform}"/>
+                        <CheckBox Grid.Column="4" Content="{DynamicResource LOCHltbUsedVndb}" Name="PART_Vndb"/>
+                    </Grid>
 
-                                <StackPanel Orientation="Horizontal"
-                                            Grid.Column="2"
-                                            HorizontalAlignment="Right"
-                                            Margin="6,0,0,0">
-                                        <controls:ComboBoxRemovable x:Name="PART_SelectPlatform"
-                                                                    VerticalAlignment="Center"
-                                                                    IsEditable="True"
-                                                                    TextSearch.TextPath="DisplayText"
-                                                                    IsEnabled="{Binding ElementName=PART_Vndb, Path=IsChecked, Converter={StaticResource InvertedBoolenConverter}}"
-                                                                    IsTextSearchCaseSensitive="False"
-                                                                    StaysOpenOnEdit="True"
-                                                                    hltb:SelectorBehaviors.EnumSource="{x:Type hlte:HltbPlatform}"
-                                                                    Width="160"/>
-                                        <CheckBox Content="{DynamicResource LOCHltbUsedVndb}"
-                                                  Name="PART_Vndb"
-                                                  VerticalAlignment="Center"
-                                                  Margin="6,0,0,0"/>
-                                </StackPanel>
-                        </Grid>
-
-                        <ListBox x:Name="lbSelectable"
-                                 Grid.Row="1"
-                                 Height="465"
-                                 SelectionChanged="LbSelectable_SelectionChanged"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
-                                 ItemContainerStyle="{StaticResource ListBoxItemContainerStyle}">
+                    <ListBox x:Name="lbSelectable" Height="465" SelectionChanged="LbSelectable_SelectionChanged"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Auto">
                         <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                        <DataTemplate.Resources>
-                                                <Style TargetType="TextBlock">
-                                                        <Setter Property="Foreground"
-                                                                Value="{DynamicResource CardForegroundBrush}"/>
-                                                </Style>
-                                        </DataTemplate.Resources>
-                                        <Border Style="{StaticResource ItemBorderStyle}">
-                                                <Grid x:Name="HltbId"
-                                                      Tag="{Binding Id}">
-                                                        <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="120"/>
-                                                                <ColumnDefinition Width="*"/>
-                                                        </Grid.ColumnDefinitions>
+                            <DataTemplate>
+                                <Grid x:Name="HltbId" Tag="{Binding Id}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="120"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
 
-                                                        <controls1:ImageAsync x:Name="HltbImage"
+                                    <controls1:ImageAsync x:Name="HltbImage"
                                                                               Grid.Column="0"
                                                                               Height="150"
                                                                               Width="100"
@@ -474,518 +95,504 @@
                                                                               Source="{Binding UrlImg}"
                                                                               Stretch="Uniform"/>
 
-                                                        <Grid Grid.Column="1"
+                                    <Grid Grid.Column="1"
                                                               VerticalAlignment="Top">
-                                                                <Grid.ColumnDefinitions>
-                                                                        <ColumnDefinition Width="*"/>
-                                                                </Grid.ColumnDefinitions>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
 
-                                                                <Grid.RowDefinitions>
-                                                                        <RowDefinition Height="*"/>
-                                                                        <RowDefinition Height="*"/>
-                                                                </Grid.RowDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*"/>
+                                            <RowDefinition Height="*"/>
+                                        </Grid.RowDefinitions>
 
-                                                                <Grid Grid.Row="0">
-                                                                        <TextBlock x:Name="HltbName"
+                                        <Grid Grid.Row="0">
+                                            <TextBlock x:Name="HltbName"
                                                                                    Text="{Binding Name, FallbackValue=GameName}"
                                                                                    FontWeight="Bold"
-                                                                                   FontSize="16"
+                                                                                   FontSize="18"
                                                                                    TextTrimming="CharacterEllipsis"
                                                                                    MouseEnter="TextBlock_MouseEnter">
-                                                                                <TextBlock.ToolTip>
-                                                                                        <ToolTip Content="{Binding Name}"/>
-                                                                                </TextBlock.ToolTip>
-                                                                        </TextBlock>
-                                                                </Grid>
+                                                <TextBlock.ToolTip>
+                                                    <ToolTip Content="{Binding Name}"/>
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                        </Grid>
 
-                                                                <Grid Grid.Row="1"
-                                                                      Margin="0,10,0,0">
-                                                                        <Grid.ColumnDefinitions>
-                                                                                <ColumnDefinition Width="auto"/>
-                                                                                <ColumnDefinition Width="10"/>
-                                                                                <ColumnDefinition Width="*"/>
-                                                                                <ColumnDefinition Width="*"/>
-                                                                                <ColumnDefinition Width="*"/>
-                                                                                <ColumnDefinition Width="*"/>
-                                                                                <ColumnDefinition Width="*"/>
-                                                                        </Grid.ColumnDefinitions>
+                                        <Grid Grid.Row="1" Margin="0,10,0,0">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="auto"/>
+                                                <ColumnDefinition Width="10"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
 
-                                                                        <Grid.RowDefinitions>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                                <RowDefinition Height="auto"/>
-                                                                        </Grid.RowDefinitions>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                                <RowDefinition Height="auto"/>
+                                            </Grid.RowDefinitions>
 
-                                                                        <!-- Colored bars - kept as-is but inside nicer card -->
-                                                                        <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
+                                            <!-- Colored bars - kept as-is but inside nicer card -->
+                                            <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
                                                                                    Grid.Column="2"
                                                                                    Grid.RowSpan="5">
-                                                                                <Rectangle.Style>
-                                                                                        <Style TargetType="Rectangle">
-                                                                                                <Style.Triggers>
-                                                                                                        <Trigger Property="Tag"
+                                                <Rectangle.Style>
+                                                    <Style TargetType="Rectangle">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="Tag"
                                                                                                                  Value="{x:Static hlte:DataType.Classic}">
-                                                                                                                <Setter Property="Fill"
+                                                                <Setter Property="Fill"
                                                                                                                         Value="{DynamicResource HoverBrush}"/>
-                                                                                                        </Trigger>
-                                                                                                </Style.Triggers>
-                                                                                        </Style>
-                                                                                </Rectangle.Style>
-                                                                        </Rectangle>
-                                                                        <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Rectangle.Style>
+                                            </Rectangle>
+                                            <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
                                                                                    Grid.Column="3"
                                                                                    Grid.RowSpan="5">
-                                                                                <Rectangle.Style>
-                                                                                        <Style TargetType="Rectangle">
-                                                                                                <Style.Triggers>
-                                                                                                        <Trigger Property="Tag"
+                                                <Rectangle.Style>
+                                                    <Style TargetType="Rectangle">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="Tag"
                                                                                                                  Value="{x:Static hlte:DataType.Average}">
-                                                                                                                <Setter Property="Fill"
+                                                                <Setter Property="Fill"
                                                                                                                         Value="{DynamicResource HoverBrush}"/>
-                                                                                                        </Trigger>
-                                                                                                </Style.Triggers>
-                                                                                        </Style>
-                                                                                </Rectangle.Style>
-                                                                        </Rectangle>
-                                                                        <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Rectangle.Style>
+                                            </Rectangle>
+                                            <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
                                                                                    Grid.Column="4"
                                                                                    Grid.RowSpan="5">
-                                                                                <Rectangle.Style>
-                                                                                        <Style TargetType="Rectangle">
-                                                                                                <Style.Triggers>
-                                                                                                        <Trigger Property="Tag"
+                                                <Rectangle.Style>
+                                                    <Style TargetType="Rectangle">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="Tag"
                                                                                                                  Value="{x:Static hlte:DataType.Median}">
-                                                                                                                <Setter Property="Fill"
+                                                                <Setter Property="Fill"
                                                                                                                         Value="{DynamicResource HoverBrush}"/>
-                                                                                                        </Trigger>
-                                                                                                </Style.Triggers>
-                                                                                        </Style>
-                                                                                </Rectangle.Style>
-                                                                        </Rectangle>
-                                                                        <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Rectangle.Style>
+                                            </Rectangle>
+                                            <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
                                                                                    Grid.Column="5"
                                                                                    Grid.RowSpan="5">
-                                                                                <Rectangle.Style>
-                                                                                        <Style TargetType="Rectangle">
-                                                                                                <Style.Triggers>
-                                                                                                        <Trigger Property="Tag"
+                                                <Rectangle.Style>
+                                                    <Style TargetType="Rectangle">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="Tag"
                                                                                                                  Value="{x:Static hlte:DataType.Rushed}">
-                                                                                                                <Setter Property="Fill"
+                                                                <Setter Property="Fill"
                                                                                                                         Value="{DynamicResource HoverBrush}"/>
-                                                                                                        </Trigger>
-                                                                                                </Style.Triggers>
-                                                                                        </Style>
-                                                                                </Rectangle.Style>
-                                                                        </Rectangle>
-                                                                        <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Rectangle.Style>
+                                            </Rectangle>
+                                            <Rectangle Tag="{Binding ElementName=lbSelectable, Path=Tag}"
                                                                                    Grid.Column="6"
                                                                                    Grid.RowSpan="5">
-                                                                                <Rectangle.Style>
-                                                                                        <Style TargetType="Rectangle">
-                                                                                                <Style.Triggers>
-                                                                                                        <Trigger Property="Tag"
+                                                <Rectangle.Style>
+                                                    <Style TargetType="Rectangle">
+                                                        <Style.Triggers>
+                                                            <Trigger Property="Tag"
                                                                                                                  Value="{x:Static hlte:DataType.Leisure}">
-                                                                                                                <Setter Property="Fill"
+                                                                <Setter Property="Fill"
                                                                                                                         Value="{DynamicResource HoverBrush}"/>
-                                                                                                        </Trigger>
-                                                                                                </Style.Triggers>
-                                                                                        </Style>
-                                                                                </Rectangle.Style>
-                                                                        </Rectangle>
+                                                            </Trigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Rectangle.Style>
+                                            </Rectangle>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="0"
                                                                                    HorizontalAlignment="Center"
                                                                                    Text="{DynamicResource LOCHltbSelectDataTypeClassic}"
                                                                                    Visibility="{Binding GameHltbData.TimeToBeat, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="0"
                                                                                    HorizontalAlignment="Center"
                                                                                    Text="{DynamicResource LOCHltbSelectDataTypeAverage}"
                                                                                    Visibility="{Binding GameHltbData.TimeToBeat, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="0"
                                                                                    HorizontalAlignment="Center"
                                                                                    Text="{DynamicResource LOCHltbSelectDataTypeMedian}"
                                                                                    Visibility="{Binding GameHltbData.TimeToBeat, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="0"
                                                                                    HorizontalAlignment="Center"
                                                                                    Text="{DynamicResource LOCHltbSelectDataTypeRushed}"
                                                                                    Visibility="{Binding GameHltbData.TimeToBeat, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="0"
                                                                                    HorizontalAlignment="Center"
                                                                                    Text="{DynamicResource LOCHltbSelectDataTypeLeisure}"
                                                                                    Visibility="{Binding GameHltbData.TimeToBeat, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="1"
                                                                                    Text="{DynamicResource LOCHowLongToBeatMainStory}"
                                                                                    Visibility="{Binding GameHltbData.MainStory, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="1"
                                                                                    Text="{Binding GameHltbData.MainStoryClassicFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainStoryClassic, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="1"
                                                                                    Text="{Binding GameHltbData.MainStoryAverageFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainStoryAverage, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="1"
                                                                                    Text="{Binding GameHltbData.MainStoryMedianFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainStoryMedian, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="1"
                                                                                    Text="{Binding GameHltbData.MainStoryRushedFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainStoryRushed, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="1"
                                                                                    Text="{Binding GameHltbData.MainStoryLeisureFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainStoryLeisure, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="2"
                                                                                    Text="{DynamicResource LOCHowLongToBeatMainExtra}"
                                                                                    Visibility="{Binding GameHltbData.MainExtra, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="2"
                                                                                    Text="{Binding GameHltbData.MainExtraClassicFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainExtraClassic, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="2"
                                                                                    Text="{Binding GameHltbData.MainExtraAverageFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainExtraAverage, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="2"
                                                                                    Text="{Binding GameHltbData.MainExtraMedianFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainExtraMedian, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="2"
                                                                                    Text="{Binding GameHltbData.MainExtraRushedFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainExtraRushed, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="2"
                                                                                    Text="{Binding GameHltbData.MainExtraLeisureFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.MainExtraLeisure, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="3"
                                                                                    Text="{DynamicResource LOCHowLongToBeatCompletionist}"
                                                                                    Visibility="{Binding GameHltbData.Completionist, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="3"
                                                                                    Text="{Binding GameHltbData.CompletionistClassicFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CompletionistClassic, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="3"
                                                                                    Text="{Binding GameHltbData.CompletionistAverageFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CompletionistAverage, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="3"
                                                                                    Text="{Binding GameHltbData.CompletionistMedianFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CompletionistMedian, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="3"
                                                                                    Text="{Binding GameHltbData.CompletionistRushedFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CompletionistRushed, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="3"
                                                                                    Text="{Binding GameHltbData.CompletionistLeisureFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CompletionistLeisure, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="4"
                                                                                    Text="{DynamicResource LOCHowLongToBeatSolo}"
                                                                                    Visibility="{Binding GameHltbData.Solo, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="4"
                                                                                    Text="{Binding GameHltbData.SoloClassicFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.SoloClassic, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="4"
                                                                                    Text="{Binding GameHltbData.SoloAverageFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.SoloAverage, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="4"
                                                                                    Text="{Binding GameHltbData.SoloMedianFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.SoloMedian, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="4"
                                                                                    Text="{Binding GameHltbData.SoloRushedFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.SoloRushed, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="4"
                                                                                    Text="{Binding GameHltbData.SoloLeisureFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.SoloLeisure, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="5"
                                                                                    Text="{DynamicResource LOCHowLongToBeatCoOp}"
                                                                                    Visibility="{Binding GameHltbData.CoOp, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="5"
                                                                                    Text="{Binding GameHltbData.CoOpClassicFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CoOpClassic, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="5"
                                                                                    Text="{Binding GameHltbData.CoOpAverageFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CoOpAverage, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="5"
                                                                                    Text="{Binding GameHltbData.CoOpMedianFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CoOpMedian, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="5"
                                                                                    Text="{Binding GameHltbData.CoOpRushedFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CoOpRushed, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="5"
                                                                                    Text="{Binding GameHltbData.CoOpLeisureFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.CoOpLeisure, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="6"
                                                                                    Text="{DynamicResource LOCHowLongToBeatVs}"
                                                                                    Visibility="{Binding GameHltbData.Vs, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="2"
                                                                                    Grid.Row="6"
                                                                                    Text="{Binding GameHltbData.VsClassicFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.VsClassic, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="3"
                                                                                    Grid.Row="6"
                                                                                    Text="{Binding GameHltbData.VsAverageFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.VsAverage, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="4"
                                                                                    Grid.Row="6"
                                                                                    Text="{Binding GameHltbData.VsMedianFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.VsMedian, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="5"
                                                                                    Grid.Row="6"
                                                                                    Text="{Binding GameHltbData.VsRushedFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.VsRushed, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="6"
                                                                                    Grid.Row="6"
                                                                                    Text="{Binding GameHltbData.VsLeisureFormat}"
                                                                                    HorizontalAlignment="Center"
                                                                                    Visibility="{Binding GameHltbData.VsLeisure, Converter={StaticResource VisibilityZeroConverter}, ConverterParameter=1}"/>
 
-                                                                        <TextBlock MinHeight="25"
+                                            <TextBlock MinHeight="25"
                                                                                    Grid.Column="0"
                                                                                    Grid.Row="7"
                                                                                    Text="{DynamicResource LOCPlatformsTitle}"
                                                                                    Visibility="{Binding Platform, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"/>
-                                                                        <!-- Platforms: allow wrapping and span across the value columns so long lists are visible -->
-                                                                        <TextBlock MinHeight="25"
-                                                                                   Grid.Column="2"
-                                                                                   Grid.Row="7"
-                                                                                   Grid.ColumnSpan="5"
-                                                                                   Text="{Binding Platform}"
-                                                                                   HorizontalAlignment="Stretch"
+                                            <!-- Platforms: allow wrapping and span across the value columns so long lists are visible -->
+                                            <TextBlock MinHeight="25" Grid.Column="1" Grid.Row="7" Text="{Binding Platform}" HorizontalAlignment="Center"
+                                                                                   Grid.ColumnSpan="10"
                                                                                    Visibility="{Binding Platform, Converter={StaticResource StringNullOrEmptyToVisibilityConverter}}"
-                                                                                   TextWrapping="Wrap"
-                                                                                   MouseEnter="TextBlock_MouseEnter"
-                                                                                   TextTrimming="None">
-                                                                                <TextBlock.ToolTip>
-                                                                                        <ToolTip Content="{Binding Platform}"/>
-                                                                                </TextBlock.ToolTip>
-                                                                        </TextBlock>
-                                                                </Grid>
-                                                        </Grid>
-                                                </Grid>
-                                        </Border>
-                                </DataTemplate>
+                                                                                   TextTrimming="CharacterEllipsis" MouseEnter="TextBlock_MouseEnter">
+                                                <TextBlock.ToolTip>
+                                                    <ToolTip Content="{Binding Platform}"/>
+                                                </TextBlock.ToolTip>
+                                            </TextBlock>
+                                        </Grid>
+                                    </Grid>
+                                </Grid>
+                            </DataTemplate>
                         </ListBox.ItemTemplate>
-                        </ListBox>
+                    </ListBox>
                 </Grid>
+            </TabItem>
 
-                <!-- Manual entry pane (hidden by default) -->
+            <TabItem x:Name="PART_TabManual" Header="{DynamicResource LOCHltbTabManual}">
                 <Grid x:Name="PART_ManualPane"
-                      Visibility="Collapsed"
-                      DockPanel.Dock="Top">
-                        <Border BorderBrush="{DynamicResource CardBorderBrush}"
+                      TextElement.Foreground="{DynamicResource TextBrush}">
+                    <Border Background="{DynamicResource ControlBackgroundBrush}"
+                                BorderBrush="{DynamicResource NormalBorderBrush}"
                                 BorderThickness="1"
                                 CornerRadius="6"
-                                Padding="16,12"
-                                Background="{DynamicResource CardBackgroundBrush}">
-                                <Grid>
-                                        <Grid.RowDefinitions>
-                                                <RowDefinition Height="Auto"/>
-                                                <RowDefinition Height="Auto"/>
-                                        </Grid.RowDefinitions>
+                                Padding="16,12">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
 
-                                        <!-- Time fields -->
-                    <Grid Grid.Row="0" Margin="0,0,0,16">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="160"/>
-                            <ColumnDefinition Width="70"/>
-                            <ColumnDefinition Width="36"/>
-                            <ColumnDefinition Width="70"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="8"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="8"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
+                            <!-- Time fields -->
+                            <Grid Grid.Row="0" Margin="0,0,0,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="160"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="36"/>
+                                    <ColumnDefinition Width="70"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="8"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="8"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-                        <!-- Column headers -->
-                        <TextBlock Grid.Column="1" Grid.Row="0"
+                                <!-- Column headers -->
+                                <TextBlock Grid.Column="1" Grid.Row="0"
                                                            HorizontalAlignment="Center"
                                                            Margin="0,0,0,6"
                                                            FontWeight="SemiBold"
-                                                           Text="{DynamicResource LOCHltbManualEntryHours}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBlock Grid.Column="3" Grid.Row="0"
+                                                           Text="{DynamicResource LOCHltbManualEntryHours}"/>
+                                <TextBlock Grid.Column="3" Grid.Row="0"
                                                            HorizontalAlignment="Center"
                                                            Margin="0,0,0,6"
                                                            FontWeight="SemiBold"
-                                                           Text="{DynamicResource LOCHltbManualEntryMinutes}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                                                           Text="{DynamicResource LOCHltbManualEntryMinutes}"/>
 
-                        <!-- Single-player rows -->
-                        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Margin="0,3"
-                                                           Text="{DynamicResource LOCHowLongToBeatMainStory}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBox x:Name="PART_ManualMainStoryH" Grid.Column="1" Grid.Row="2" Margin="0,3,6,3" Text="0"/>
-                        <TextBox x:Name="PART_ManualMainStoryM" Grid.Column="3" Grid.Row="2" Margin="0,3,0,3" Text="0"/>
+                                <!-- Single-player rows -->
+                                <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatMainStory}"/>
+                                <TextBox x:Name="PART_ManualMainStoryH" Grid.Column="1" Grid.Row="2" Margin="0,3,6,3" Text="0"/>
+                                <TextBox x:Name="PART_ManualMainStoryM" Grid.Column="3" Grid.Row="2" Margin="0,3,0,3" Text="0"/>
 
-                        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Margin="0,3"
-                                                           Text="{DynamicResource LOCHowLongToBeatMainExtra}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBox x:Name="PART_ManualMainExtraH" Grid.Column="1" Grid.Row="3" Margin="0,3,6,3" Text="0"/>
-                        <TextBox x:Name="PART_ManualMainExtraM" Grid.Column="3" Grid.Row="3" Margin="0,3,0,3" Text="0"/>
+                                <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatMainExtra}"/>
+                                <TextBox x:Name="PART_ManualMainExtraH" Grid.Column="1" Grid.Row="3" Margin="0,3,6,3" Text="0"/>
+                                <TextBox x:Name="PART_ManualMainExtraM" Grid.Column="3" Grid.Row="3" Margin="0,3,0,3" Text="0"/>
 
-                        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Margin="0,3"
-                                                           Text="{DynamicResource LOCHowLongToBeatCompletionist}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBox x:Name="PART_ManualCompletionistH" Grid.Column="1" Grid.Row="4" Margin="0,3,6,3" Text="0"/>
-                        <TextBox x:Name="PART_ManualCompletionistM" Grid.Column="3" Grid.Row="4" Margin="0,3,0,3" Text="0"/>
+                                <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatCompletionist}"/>
+                                <TextBox x:Name="PART_ManualCompletionistH" Grid.Column="1" Grid.Row="4" Margin="0,3,6,3" Text="0"/>
+                                <TextBox x:Name="PART_ManualCompletionistM" Grid.Column="3" Grid.Row="4" Margin="0,3,0,3" Text="0"/>
 
-                        <!-- Separator label for multiplayer -->
-                        <TextBlock Grid.Column="0" Grid.Row="6"
+                                <!-- Separator label for multiplayer -->
+                                <TextBlock Grid.Column="0" Grid.Row="6"
                                                            Grid.ColumnSpan="5"
                                                            Margin="0,0,0,4"
                                                            FontStyle="Italic"
                                                            Opacity="0.7"
                                                            Text="{DynamicResource LOCHowLongToBeatTimeSinglePlayer}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"
                                                            Visibility="Collapsed"/>
 
-                        <!-- Multiplayer rows -->
-                        <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" Margin="0,3"
-                                                           Text="{DynamicResource LOCHowLongToBeatSolo}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBox x:Name="PART_ManualSoloH" Grid.Column="1" Grid.Row="6" Margin="0,3,6,3" Text="0"/>
-                        <TextBox x:Name="PART_ManualSoloM" Grid.Column="3" Grid.Row="6" Margin="0,3,0,3" Text="0"/>
+                                <!-- Multiplayer rows -->
+                                <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatSolo}"/>
+                                <TextBox x:Name="PART_ManualSoloH" Grid.Column="1" Grid.Row="6" Margin="0,3,6,3" Text="0"/>
+                                <TextBox x:Name="PART_ManualSoloM" Grid.Column="3" Grid.Row="6" Margin="0,3,0,3" Text="0"/>
 
-                        <TextBlock Grid.Column="0" Grid.Row="7" VerticalAlignment="Center" Margin="0,3"
-                                                           Text="{DynamicResource LOCHowLongToBeatCoOp}"
-                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBox x:Name="PART_ManualCoOpH" Grid.Column="1" Grid.Row="7" Margin="0,3,6,3" Text="0"/>
-                        <TextBox x:Name="PART_ManualCoOpM" Grid.Column="3" Grid.Row="7" Margin="0,3,0,3" Text="0"/>
+                                <TextBlock Grid.Column="0" Grid.Row="7" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatCoOp}"/>
+                                <TextBox x:Name="PART_ManualCoOpH" Grid.Column="1" Grid.Row="7" Margin="0,3,6,3" Text="0"/>
+                                <TextBox x:Name="PART_ManualCoOpM" Grid.Column="3" Grid.Row="7" Margin="0,3,0,3" Text="0"/>
 
-                        <!-- Optional HLTB ID -->
-                        <TextBlock Grid.Column="0" Grid.Row="8" VerticalAlignment="Center" Margin="0,6,0,0"
-                                   Text="{DynamicResource LOCHltbManualEntryHltbId}"
-                                   Foreground="{DynamicResource CardForegroundBrush}"/>
-                        <TextBox x:Name="PART_ManualHltbId"
+                                <!-- Optional HLTB ID -->
+                                <TextBlock Grid.Column="0" Grid.Row="8" VerticalAlignment="Center" Margin="0,6,0,0"
+                                   Text="{DynamicResource LOCHltbManualEntryHltbId}"/>
+                                <TextBox x:Name="PART_ManualHltbId"
                                  Grid.Column="1" Grid.Row="8" Grid.ColumnSpan="3"
                                  Margin="0,6,0,0"
                                  ToolTip="{DynamicResource LOCHltbManualEntryHltbId}"/>
-                    </Grid>
+                            </Grid>
 
-                    <!-- Open website -->
-                    <Button x:Name="PART_BtOpenWebsite"
+                            <!-- Open website -->
+                            <Button x:Name="PART_BtOpenWebsite"
                             Grid.Row="1"
                             Content="{DynamicResource LOCHltbOpenOnWebsite}"
                             Click="ButtonOpenOnWebsite_Click"
-                            Margin="8,0,0,0"
-                            Style="{StaticResource PrimaryButtonStyle}"/>
+                            Margin="8,0,0,0"/>
+                        </Grid>
+                    </Border>
                 </Grid>
-                        </Border>
-                </Grid>
-        </DockPanel>
+            </TabItem>
+
+        </TabControl>
+    </DockPanel>
 </UserControl >

--- a/source/Views/HowLongToBeatSelect.xaml
+++ b/source/Views/HowLongToBeatSelect.xaml
@@ -132,6 +132,72 @@
                         </Style.Triggers>
                 </Style>
 
+                <!-- Tab active / inactive styles -->
+                <Style x:Key="TabActiveStyle"
+                       TargetType="Button">
+                        <Setter Property="Background"
+                                Value="{DynamicResource PrimaryButtonBackgroundBrush}"/>
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource PrimaryButtonForegroundBrush}"/>
+                        <Setter Property="FontWeight"
+                                Value="Bold"/>
+                        <Setter Property="Padding"
+                                Value="18,8"/>
+                        <Setter Property="Margin"
+                                Value="0"/>
+                        <Setter Property="BorderThickness"
+                                Value="0"/>
+                        <Setter Property="Template">
+                                <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                                <Border Background="{TemplateBinding Background}"
+                                                        BorderThickness="0,0,0,3"
+                                                        BorderBrush="{DynamicResource PrimaryButtonForegroundBrush}"
+                                                        Padding="{TemplateBinding Padding}">
+                                                        <ContentPresenter HorizontalAlignment="Center"
+                                                                          VerticalAlignment="Center"/>
+                                                </Border>
+                                        </ControlTemplate>
+                                </Setter.Value>
+                        </Setter>
+                </Style>
+
+                <Style x:Key="TabInactiveStyle"
+                       TargetType="Button">
+                        <Setter Property="Background"
+                                Value="Transparent"/>
+                        <Setter Property="Foreground"
+                                Value="{DynamicResource CardForegroundBrush}"/>
+                        <Setter Property="FontWeight"
+                                Value="Normal"/>
+                        <Setter Property="Padding"
+                                Value="18,8"/>
+                        <Setter Property="Margin"
+                                Value="0"/>
+                        <Setter Property="Opacity"
+                                Value="0.55"/>
+                        <Setter Property="BorderThickness"
+                                Value="0"/>
+                        <Setter Property="Template">
+                                <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                                <Border Background="{TemplateBinding Background}"
+                                                        BorderThickness="0,0,0,2"
+                                                        BorderBrush="{DynamicResource CardBorderBrush}"
+                                                        Padding="{TemplateBinding Padding}">
+                                                        <ContentPresenter HorizontalAlignment="Center"
+                                                                          VerticalAlignment="Center"/>
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                                <Setter Property="Opacity" Value="0.85"/>
+                                                        </Trigger>
+                                                </ControlTemplate.Triggers>
+                                        </ControlTemplate>
+                                </Setter.Value>
+                        </Setter>
+                </Style>
+
                 <!-- Button look -->
                 <Style x:Key="PrimaryButtonStyle"
                        TargetType="Button">
@@ -288,6 +354,13 @@
                                 VerticalAlignment="Center"
                                 Click="ButtonSelect_Click"
                                 Style="{StaticResource PrimaryButtonStyle}"/>
+                        <Button Name="ButtonConfirmManual"
+                                Visibility="Collapsed"
+                                Grid.Column="1"
+                                Content="{DynamicResource LOCHltbManualEntryConfirm}"
+                                VerticalAlignment="Center"
+                                Click="ButtonAddManual_Click"
+                                Style="{StaticResource PrimaryButtonStyle}"/>
                         <Button Grid.Column="3"
                                 Content="{DynamicResource LOCCancelLabel}"
                                 VerticalAlignment="Center"
@@ -295,63 +368,88 @@
                                 Style="{StaticResource PrimaryButtonStyle}"/>
                 </Grid>
 
-                <!-- Top controls: search + platform -->
-                <Grid Margin="0,0,0,10"
-                      DockPanel.Dock="Top">
-                        <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="6"/>
-                                <ColumnDefinition Width="Auto"/>
-                        </Grid.ColumnDefinitions>
+                <!-- Mode tab bar -->
+                <Border DockPanel.Dock="Top"
+                        BorderBrush="{DynamicResource CardBorderBrush}"
+                        BorderThickness="0,0,0,1"
+                        Margin="0,0,0,10">
+                        <StackPanel Orientation="Horizontal">
+                                <Button x:Name="PART_TabSearch"
+                                        Content="{DynamicResource LOCHltbTabSearch}"
+                                        Click="TabSearch_Click"
+                                        Style="{StaticResource TabActiveStyle}"/>
+                                <Button x:Name="PART_TabManual"
+                                        Content="{DynamicResource LOCHltbTabManual}"
+                                        Click="TabManual_Click"
+                                        Style="{StaticResource TabInactiveStyle}"/>
+                        </StackPanel>
+                </Border>
 
-                        <Grid Grid.Column="0">
+                <!-- Search pane -->
+                <Grid x:Name="PART_SearchPane"
+                      DockPanel.Dock="Top">
+                        <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- Search controls: search box + platform -->
+                        <Grid Grid.Row="0" Margin="0,0,0,10">
                                 <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="6"/>
                                         <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
 
-                                <playnitecontrols:SearchBox x:Name="SearchElement"
-                                                            KeyUp="SearchElement_KeyUp"
-                                                            Grid.Column="0"
-                                                            HorizontalAlignment="Stretch"
-                                                            MinWidth="200"
-                                                            MaxWidth="420"/>
+                                <Grid Grid.Column="0">
+                                        <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
 
-                                <Button Name="PART_BtSearch"
-                                        Grid.Column="1"
-                                        Content="{DynamicResource LOCSearchLabel}"
-                                        Click="ButtonSearch_Click"
-                                        Margin="6,0,0,0"
-                                        IsEnabled="{Binding ElementName=SearchElement, Path=Text, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"
-                                        Style="{StaticResource PrimaryButtonStyle}"/>
+                                        <playnitecontrols:SearchBox x:Name="SearchElement"
+                                                                    KeyUp="SearchElement_KeyUp"
+                                                                    Grid.Column="0"
+                                                                    HorizontalAlignment="Stretch"
+                                                                    MinWidth="200"
+                                                                    MaxWidth="420"/>
+
+                                        <Button Name="PART_BtSearch"
+                                                Grid.Column="1"
+                                                Content="{DynamicResource LOCSearchLabel}"
+                                                Click="ButtonSearch_Click"
+                                                Margin="6,0,0,0"
+                                                IsEnabled="{Binding ElementName=SearchElement, Path=Text, Converter={StaticResource StringNullOrEmptyToBoolConverter}}"
+                                                Style="{StaticResource PrimaryButtonStyle}"/>
+                                </Grid>
+
+                                <StackPanel Orientation="Horizontal"
+                                            Grid.Column="2"
+                                            HorizontalAlignment="Right"
+                                            Margin="6,0,0,0">
+                                        <controls:ComboBoxRemovable x:Name="PART_SelectPlatform"
+                                                                    VerticalAlignment="Center"
+                                                                    IsEditable="True"
+                                                                    TextSearch.TextPath="DisplayText"
+                                                                    IsEnabled="{Binding ElementName=PART_Vndb, Path=IsChecked, Converter={StaticResource InvertedBoolenConverter}}"
+                                                                    IsTextSearchCaseSensitive="False"
+                                                                    StaysOpenOnEdit="True"
+                                                                    hltb:SelectorBehaviors.EnumSource="{x:Type hlte:HltbPlatform}"
+                                                                    Width="160"/>
+                                        <CheckBox Content="{DynamicResource LOCHltbUsedVndb}"
+                                                  Name="PART_Vndb"
+                                                  VerticalAlignment="Center"
+                                                  Margin="6,0,0,0"/>
+                                </StackPanel>
                         </Grid>
 
-                        <StackPanel Orientation="Horizontal"
-                                    Grid.Column="2"
-                                    HorizontalAlignment="Right"
-                                    Margin="6,0,0,0">
-                                <controls:ComboBoxRemovable x:Name="PART_SelectPlatform"
-                                                            VerticalAlignment="Center"
-                                                            IsEditable="True"
-                                                            TextSearch.TextPath="DisplayText"
-                                                            IsEnabled="{Binding ElementName=PART_Vndb, Path=IsChecked, Converter={StaticResource InvertedBoolenConverter}}"
-                                                            IsTextSearchCaseSensitive="False"
-                                                            StaysOpenOnEdit="True"
-                                                            hltb:SelectorBehaviors.EnumSource="{x:Type hlte:HltbPlatform}"
-                                                            Width="160"/>
-                                <CheckBox Content="{DynamicResource LOCHltbUsedVndb}"
-                                          Name="PART_Vndb"
-                                          VerticalAlignment="Center"
-                                          Margin="6,0,0,0"/>
-                        </StackPanel>
-                </Grid>
-
-                <ListBox x:Name="lbSelectable"
-                         Height="465"
-                         SelectionChanged="LbSelectable_SelectionChanged"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         ItemContainerStyle="{StaticResource ListBoxItemContainerStyle}">
+                        <ListBox x:Name="lbSelectable"
+                                 Grid.Row="1"
+                                 Height="465"
+                                 SelectionChanged="LbSelectable_SelectionChanged"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                 ItemContainerStyle="{StaticResource ListBoxItemContainerStyle}">
                         <ListBox.ItemTemplate>
                                 <DataTemplate>
                                         <DataTemplate.Resources>
@@ -774,6 +872,110 @@
                                         </Border>
                                 </DataTemplate>
                         </ListBox.ItemTemplate>
-                </ListBox>
+                        </ListBox>
+                </Grid>
+
+                <!-- Manual entry pane (hidden by default) -->
+                <Grid x:Name="PART_ManualPane"
+                      Visibility="Collapsed"
+                      DockPanel.Dock="Top">
+                        <Border BorderBrush="{DynamicResource CardBorderBrush}"
+                                BorderThickness="1"
+                                CornerRadius="6"
+                                Padding="16,12"
+                                Background="{DynamicResource CardBackgroundBrush}">
+                                <Grid>
+                                        <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <!-- Time fields -->
+                    <Grid Grid.Row="0" Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="160"/>
+                            <ColumnDefinition Width="70"/>
+                            <ColumnDefinition Width="36"/>
+                            <ColumnDefinition Width="70"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="8"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- Column headers -->
+                        <TextBlock Grid.Column="1" Grid.Row="0"
+                                                           HorizontalAlignment="Center"
+                                                           Margin="0,0,0,6"
+                                                           FontWeight="SemiBold"
+                                                           Text="{DynamicResource LOCHltbManualEntryHours}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBlock Grid.Column="3" Grid.Row="0"
+                                                           HorizontalAlignment="Center"
+                                                           Margin="0,0,0,6"
+                                                           FontWeight="SemiBold"
+                                                           Text="{DynamicResource LOCHltbManualEntryMinutes}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+
+                        <!-- Single-player rows -->
+                        <TextBlock Grid.Column="0" Grid.Row="2" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatMainStory}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBox x:Name="PART_ManualMainStoryH" Grid.Column="1" Grid.Row="2" Margin="0,3,6,3" Text="0"/>
+                        <TextBox x:Name="PART_ManualMainStoryM" Grid.Column="3" Grid.Row="2" Margin="0,3,0,3" Text="0"/>
+
+                        <TextBlock Grid.Column="0" Grid.Row="3" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatMainExtra}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBox x:Name="PART_ManualMainExtraH" Grid.Column="1" Grid.Row="3" Margin="0,3,6,3" Text="0"/>
+                        <TextBox x:Name="PART_ManualMainExtraM" Grid.Column="3" Grid.Row="3" Margin="0,3,0,3" Text="0"/>
+
+                        <TextBlock Grid.Column="0" Grid.Row="4" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatCompletionist}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBox x:Name="PART_ManualCompletionistH" Grid.Column="1" Grid.Row="4" Margin="0,3,6,3" Text="0"/>
+                        <TextBox x:Name="PART_ManualCompletionistM" Grid.Column="3" Grid.Row="4" Margin="0,3,0,3" Text="0"/>
+
+                        <!-- Separator label for multiplayer -->
+                        <TextBlock Grid.Column="0" Grid.Row="6"
+                                                           Grid.ColumnSpan="5"
+                                                           Margin="0,0,0,4"
+                                                           FontStyle="Italic"
+                                                           Opacity="0.7"
+                                                           Text="{DynamicResource LOCHowLongToBeatTimeSinglePlayer}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"
+                                                           Visibility="Collapsed"/>
+
+                        <!-- Multiplayer rows -->
+                        <TextBlock Grid.Column="0" Grid.Row="6" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatSolo}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBox x:Name="PART_ManualSoloH" Grid.Column="1" Grid.Row="6" Margin="0,3,6,3" Text="0"/>
+                        <TextBox x:Name="PART_ManualSoloM" Grid.Column="3" Grid.Row="6" Margin="0,3,0,3" Text="0"/>
+
+                        <TextBlock Grid.Column="0" Grid.Row="7" VerticalAlignment="Center" Margin="0,3"
+                                                           Text="{DynamicResource LOCHowLongToBeatCoOp}"
+                                                           Foreground="{DynamicResource CardForegroundBrush}"/>
+                        <TextBox x:Name="PART_ManualCoOpH" Grid.Column="1" Grid.Row="7" Margin="0,3,6,3" Text="0"/>
+                        <TextBox x:Name="PART_ManualCoOpM" Grid.Column="3" Grid.Row="7" Margin="0,3,0,3" Text="0"/>
+                    </Grid>
+
+                    <!-- Open website -->
+                    <Button x:Name="PART_BtOpenWebsite"
+                            Grid.Row="1"
+                            Content="{DynamicResource LOCHltbOpenOnWebsite}"
+                            Click="ButtonOpenOnWebsite_Click"
+                            Margin="8,0,0,0"
+                            Style="{StaticResource PrimaryButtonStyle}"/>
+                </Grid>
+                        </Border>
+                </Grid>
         </DockPanel>
 </UserControl >

--- a/source/Views/HowLongToBeatSelect.xaml.cs
+++ b/source/Views/HowLongToBeatSelect.xaml.cs
@@ -17,255 +17,339 @@ using Playnite.SDK.Models;
 
 namespace HowLongToBeat.Views
 {
-    public partial class HowLongToBeatSelect : UserControl
-    {
-        private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
+	public partial class HowLongToBeatSelect : UserControl
+	{
+		private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
 
-        public GameHowLongToBeat GameHowLongToBeat { get; set; }
-        private Game GameContext { get; set; }
+		public GameHowLongToBeat GameHowLongToBeat { get; set; }
+		private Game GameContext { get; set; }
 
+		public HowLongToBeatSelect(Game game, List<HltbDataUser> data)
+		{
+			InitializeComponent();
 
-        public HowLongToBeatSelect(Game game, List<HltbDataUser> data)
-        {
-            InitializeComponent();
+			ApplyThemeResources();
 
-            ApplyThemeResources();
+			GameContext = game;
+			SearchElement.Text = GameContext.Name;
 
-            GameContext = game;
-            SearchElement.Text = GameContext.Name;
+			if (PluginDatabase.PluginSettings.Settings.UseHtltbClassic)
+			{
+				lbSelectable.Tag = DataType.Classic;
+			}
+			if (PluginDatabase.PluginSettings.Settings.UseHtltbAverage)
+			{
+				lbSelectable.Tag = DataType.Average;
+			}
+			if (PluginDatabase.PluginSettings.Settings.UseHtltbMedian)
+			{
+				lbSelectable.Tag = DataType.Median;
+			}
+			if (PluginDatabase.PluginSettings.Settings.UseHtltbRushed)
+			{
+				lbSelectable.Tag = DataType.Rushed;
+			}
+			if (PluginDatabase.PluginSettings.Settings.UseHtltbLeisure)
+			{
+				lbSelectable.Tag = DataType.Leisure;
+			}
 
-            if (PluginDatabase.PluginSettings.Settings.UseHtltbClassic)
-            {
-                lbSelectable.Tag = DataType.Classic;
-            }
-            if (PluginDatabase.PluginSettings.Settings.UseHtltbAverage)
-            {
-                lbSelectable.Tag = DataType.Average;
-            }
-            if (PluginDatabase.PluginSettings.Settings.UseHtltbMedian)
-            {
-                lbSelectable.Tag = DataType.Median;
-            }
-            if (PluginDatabase.PluginSettings.Settings.UseHtltbRushed)
-            {
-                lbSelectable.Tag = DataType.Rushed;
-            }
-            if (PluginDatabase.PluginSettings.Settings.UseHtltbLeisure)
-            {
-                lbSelectable.Tag = DataType.Leisure;
-            }
+			if (data == null)
+			{
+				_ = Task.Run(() =>
+				{
+					Thread.Sleep(300);
+					Application.Current?.Dispatcher?.Invoke(new Action(() =>
+					{
+						SearchData();
+					}));
+				});
+			}
+			else
+			{
+				lbSelectable.ItemsSource = data;
+				lbSelectable.UpdateLayout();
+			}
 
-            if (data == null)
-            {
-                _ = Task.Run(() =>
-                {
-                    Thread.Sleep(300);
-                    Application.Current?.Dispatcher?.Invoke(new Action(() =>
-                    {
-                        SearchData();
-                    }));
-                });
-            }
-            else
-            {
-                lbSelectable.ItemsSource = data;
-                lbSelectable.UpdateLayout();
-            }
+			// Set Binding data
+			DataContext = this;
+		}
 
-            // Set Binding data
-            DataContext = this;
-        }
+		private void ButtonCancel_Click(object sender, RoutedEventArgs e)
+		{
+			((Window)this.Parent).Close();
+		}
 
-        private void ButtonCancel_Click(object sender, RoutedEventArgs e)
-        {
-            ((Window)this.Parent).Close();
-        }
+		/// <summary>
+		/// Valid the selection.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void ButtonSelect_Click(object sender, RoutedEventArgs e)
+		{
+			HltbDataUser Item = (HltbDataUser)lbSelectable.SelectedItem;
 
-        /// <summary>
-        /// Valid the selection.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void ButtonSelect_Click(object sender, RoutedEventArgs e)
-        {
-            HltbDataUser Item = (HltbDataUser)lbSelectable.SelectedItem;
+			GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
+			GameHowLongToBeat.Items = new List<HltbDataUser>() { Item };
 
-            GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
-            GameHowLongToBeat.Items = new List<HltbDataUser>() { Item };
+			((Window)this.Parent).Close();
+		}
 
-            ((Window)this.Parent).Close();
-        }
+		/// <summary>
+		/// Deblock validation button after a selection.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void LbSelectable_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			ButtonSelect.IsEnabled = true;
+		}
 
-        /// <summary>
-        /// Deblock validation button after a selection.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void LbSelectable_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            ButtonSelect.IsEnabled = true;
-        }
+		/// <summary>
+		/// Search element by name.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void ButtonSearch_Click(object sender, RoutedEventArgs e)
+		{
+			SearchData();
+		}
 
-        /// <summary>
-        /// Search element by name.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void ButtonSearch_Click(object sender, RoutedEventArgs e)
-        {
-            SearchData();
-        }
+		private void SearchData()
+		{
+			lbSelectable.ItemsSource = null;
 
-        private void SearchData()
-        {
-            lbSelectable.ItemsSource = null;
+			string gameSearch = SearchElement.Text;
+			string gamePlatform = (PART_SelectPlatform.SelectedValue == null)
+				  ? string.Empty
+				  : ((HltbPlatform)PART_SelectPlatform.SelectedValue).GetDescription();
 
-            string gameSearch = SearchElement.Text;
-            string gamePlatform = (PART_SelectPlatform.SelectedValue == null)
-                  ? string.Empty
-                  : ((HltbPlatform)PART_SelectPlatform.SelectedValue).GetDescription();
+			bool isVndb = (bool)PART_Vndb.IsChecked;
 
-            bool isVndb = (bool)PART_Vndb.IsChecked;
+			GlobalProgressOptions globalProgressOptions = new GlobalProgressOptions($"{ResourceProvider.GetString("LOCDownloadingLabel")}")
+			{
+				Cancelable = false,
+				IsIndeterminate = true
+			};
 
-            GlobalProgressOptions globalProgressOptions = new GlobalProgressOptions($"{ResourceProvider.GetString("LOCDownloadingLabel")}")
-            {
-                Cancelable = false,
-                IsIndeterminate = true
-            };
+			_ = API.Instance.Dialogs.ActivateGlobalProgress(async (activateGlobalProgress) =>
+			{
+				List<HltbDataUser> dataSearch = new List<HltbDataUser>();
+				try
+				{
+					if (isVndb)
+					{
+						var vndbResults = await VndbApi.SearchByNameAsync(gameSearch);
+						dataSearch = vndbResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
+					}
+					else
+					{
+						var hlResults = await PluginDatabase.HowLongToBeatApi.SearchTwoMethod(gameSearch, gamePlatform, includeExtendedTimes: true);
+						dataSearch = hlResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
+					}
+				}
+				catch (Exception ex)
+				{
+					Common.LogError(ex, false, true, PluginDatabase.PluginName);
+				}
 
-            _ = API.Instance.Dialogs.ActivateGlobalProgress(async (activateGlobalProgress) =>
-            {
-                List<HltbDataUser> dataSearch = new List<HltbDataUser>();
-                try
-                {
-                    if (isVndb)
-                    {
-                        var vndbResults = await VndbApi.SearchByNameAsync(gameSearch);
-                        dataSearch = vndbResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
-                    }
-                    else
-                    {
-                        var hlResults = await PluginDatabase.HowLongToBeatApi.SearchTwoMethod(gameSearch, gamePlatform, includeExtendedTimes: true);
-                        dataSearch = hlResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
-                }
+				Common.LogDebug(true, $"dataSearch: {Serialization.ToJson(dataSearch)}");
+				Application.Current.Dispatcher?.Invoke(new Action(() =>
+				{
+					lbSelectable.ItemsSource = dataSearch;
+					lbSelectable.UpdateLayout();
+				}));
+			}, globalProgressOptions);
+		}
 
-                Common.LogDebug(true, $"dataSearch: {Serialization.ToJson(dataSearch)}");
-                Application.Current.Dispatcher?.Invoke(new Action(() =>
-                {
-                    lbSelectable.ItemsSource = dataSearch;
-                    lbSelectable.UpdateLayout();
-                }));
-            }, globalProgressOptions);
-        }
+		/// <summary>
+		/// Show or not the ToolTip.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void TextBlock_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
+		{
+			var textBlock = sender as TextBlock;
+			if (textBlock == null) return;
 
-        /// <summary>
-        /// Show or not the ToolTip.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void TextBlock_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
-        {
-            var textBlock = sender as TextBlock;
-            if (textBlock == null) return;
+			var toolTip = textBlock.ToolTip as ToolTip;
+			if (toolTip == null) return;
 
-            var toolTip = textBlock.ToolTip as ToolTip;
-            if (toolTip == null) return;
+			try
+			{
+				var text = textBlock.Text ?? string.Empty;
+				if (string.IsNullOrEmpty(text))
+				{
+					toolTip.Visibility = Visibility.Hidden;
+					return;
+				}
 
-            try
-            {
-                var text = textBlock.Text ?? string.Empty;
-                if (string.IsNullOrEmpty(text))
-                {
-                    toolTip.Visibility = Visibility.Hidden;
-                    return;
-                }
+				var typeface = new Typeface(
+					textBlock.FontFamily,
+					textBlock.FontStyle,
+					textBlock.FontWeight,
+					textBlock.FontStretch);
 
-                var typeface = new Typeface(
-                    textBlock.FontFamily,
-                    textBlock.FontStyle,
-                    textBlock.FontWeight,
-                    textBlock.FontStretch);
+				// Use the FormattedText overload with PixelsPerDip to avoid obsolete warning
+				double pixelsPerDip = 1.0;
+				try
+				{
+					pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+				}
+				catch { }
 
-                // Use the FormattedText overload with PixelsPerDip to avoid obsolete warning
-                double pixelsPerDip = 1.0;
-                try
-                {
-                    pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
-                }
-                catch { }
+				var formattedText = new FormattedText(
+					text,
+					System.Threading.Thread.CurrentThread.CurrentCulture,
+					textBlock.FlowDirection,
+					typeface,
+					textBlock.FontSize,
+					textBlock.Foreground,
+					pixelsPerDip);
 
-                var formattedText = new FormattedText(
-                    text,
-                    System.Threading.Thread.CurrentThread.CurrentCulture,
-                    textBlock.FlowDirection,
-                    typeface,
-                    textBlock.FontSize,
-                    textBlock.Foreground,
-                    pixelsPerDip);
+				// Compare measured width with actual available width. If larger, show tooltip.
+				toolTip.Visibility = formattedText.Width > (textBlock.ActualWidth - 1.0)
+					? Visibility.Visible
+					: Visibility.Hidden;
+			}
+			catch
+			{
+				// On any error, hide tooltip rather than crash
+				try { toolTip.Visibility = Visibility.Hidden; } catch { }
+			}
+		}
 
-                // Compare measured width with actual available width. If larger, show tooltip.
-                toolTip.Visibility = formattedText.Width > (textBlock.ActualWidth - 1.0)
-                    ? Visibility.Visible
-                    : Visibility.Hidden;
-            }
-            catch
-            {
-                // On any error, hide tooltip rather than crash
-                try { toolTip.Visibility = Visibility.Hidden; } catch { }
-            }
-        }
+		/// <summary>
+		/// Valid search by enter key.
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void SearchElement_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+		{
+			if (e.Key == System.Windows.Input.Key.Enter)
+			{
+				ButtonSearch_Click(null, null);
+			}
+		}
 
-        /// <summary>
-        /// Valid search by enter key.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void SearchElement_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (e.Key == System.Windows.Input.Key.Enter)
-            {
-                ButtonSearch_Click(null, null);
-            }
-        }
+		private void ListBoxItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+		{
+			var lbi = sender as ListBoxItem;
+			if (lbi == null) return;
 
-        private void ListBoxItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
-        {
-            var lbi = sender as ListBoxItem;
-            if (lbi == null) return;
+			if (!lbi.IsSelected)
+			{
+				lbi.IsSelected = true;
+			}
+			e.Handled = false;
+		}
 
-            if (!lbi.IsSelected)
-            {
-                lbi.IsSelected = true;
-            }
-            e.Handled = false;
-        }
+		private void TabSearch_Click(object sender, RoutedEventArgs e)
+		{
+			SwitchToMode(manual: false);
+		}
 
-        private void ApplyThemeResources()
-        {
-            try
-            {
-                // Try to get common theme brushes from the host via ResourceProvider
-                var normal = ResourceProvider.GetResource("NormalBrush") as Brush;
-                var controlBg = ResourceProvider.GetResource("ControlBackgroundBrush") as Brush ?? normal;
-                var controlFg = ResourceProvider.GetResource("ControlForegroundBrush") as Brush ?? Brushes.White;
-                var controlBorder = ResourceProvider.GetResource("ControlBorderBrush") as Brush ?? Brushes.Gray;
-                var accent = ResourceProvider.GetResource("AccentColorBrush") as Brush ?? normal;
+		private void TabManual_Click(object sender, RoutedEventArgs e)
+		{
+			SwitchToMode(manual: true);
+		}
 
-                // Override the local resource keys defined in XAML so DynamicResource bindings pick them
-                this.Resources["CardBackgroundBrush"] = controlBg ?? new SolidColorBrush(Color.FromRgb(0x2E, 0x2F, 0x33));
-                this.Resources["CardForegroundBrush"] = controlFg ?? Brushes.White;
-                this.Resources["CardBorderBrush"] = controlBorder ?? new SolidColorBrush(Color.FromRgb(0x44, 0x44, 0x44));
+		private void SwitchToMode(bool manual)
+		{
+			PART_SearchPane.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
+			PART_ManualPane.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
 
-                this.Resources["PrimaryButtonBackgroundBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x5A, 0x9B, 0xD5));
-                this.Resources["PrimaryButtonHoverBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x4B, 0x89, 0xC6));
-                this.Resources["PrimaryButtonForegroundBrush"] = controlFg ?? Brushes.White;
-            }
-            catch { }
-        }
-    }
+			PART_TabSearch.Style = manual
+				? (Style)FindResource("TabInactiveStyle")
+				: (Style)FindResource("TabActiveStyle");
+			PART_TabManual.Style = manual
+				? (Style)FindResource("TabActiveStyle")
+				: (Style)FindResource("TabInactiveStyle");
+
+			ButtonSelect.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
+			ButtonConfirmManual.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
+		}
+
+		private void ButtonOpenOnWebsite_Click(object sender, RoutedEventArgs e)
+		{
+			try
+			{
+				var query = Uri.EscapeDataString(GameContext.Name ?? string.Empty);
+				var url = "https://howlongtobeat.com/?q=" + query;
+				var psi = new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true };
+				System.Diagnostics.Process.Start(psi);
+			}
+			catch (Exception ex)
+			{
+				Common.LogError(ex, false, true, PluginDatabase.PluginName);
+			}
+		}
+
+		private static long ParseHoursMinutesToSeconds(string hours, string minutes)
+		{
+			double.TryParse(hours?.Trim(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var h);
+			double.TryParse(minutes?.Trim(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var m);
+			var total = (long)(h * 3600 + m * 60);
+			return total < 0 ? 0 : total;
+		}
+
+		private void ButtonAddManual_Click(object sender, RoutedEventArgs e)
+		{
+			var mainStory = ParseHoursMinutesToSeconds(PART_ManualMainStoryH.Text, PART_ManualMainStoryM.Text);
+			var mainExtra = ParseHoursMinutesToSeconds(PART_ManualMainExtraH.Text, PART_ManualMainExtraM.Text);
+			var completionist = ParseHoursMinutesToSeconds(PART_ManualCompletionistH.Text, PART_ManualCompletionistM.Text);
+			var solo = ParseHoursMinutesToSeconds(PART_ManualSoloH.Text, PART_ManualSoloM.Text);
+			var coOp = ParseHoursMinutesToSeconds(PART_ManualCoOpH.Text, PART_ManualCoOpM.Text);
+
+			var hasMulti = solo > 0 || coOp > 0;
+
+			var resolvedType = hasMulti && mainStory == 0 && mainExtra == 0 && completionist == 0
+				? GameType.Multi
+				: GameType.Game;
+
+			var manualEntry = new HltbDataUser
+			{
+				Name = GameContext.Name,
+				Id = null,
+				GameType = resolvedType,
+				GameHltbData = new HltbData
+				{
+					GameType = resolvedType,
+					MainStoryClassic = mainStory,
+					MainExtraClassic = mainExtra,
+					CompletionistClassic = completionist,
+					SoloClassic = solo,
+					CoOpClassic = coOp
+				}
+			};
+
+			GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
+			GameHowLongToBeat.Items = new List<HltbDataUser> { manualEntry };
+
+			((Window)Parent).Close();
+		}
+
+		private void ApplyThemeResources()
+		{
+			try
+			{
+				// Try to get common theme brushes from the host via ResourceProvider
+				var normal = ResourceProvider.GetResource("NormalBrush") as Brush;
+				var controlBg = ResourceProvider.GetResource("ControlBackgroundBrush") as Brush ?? normal;
+				var controlFg = ResourceProvider.GetResource("ControlForegroundBrush") as Brush ?? Brushes.White;
+				var controlBorder = ResourceProvider.GetResource("ControlBorderBrush") as Brush ?? Brushes.Gray;
+				var accent = ResourceProvider.GetResource("AccentColorBrush") as Brush ?? normal;
+
+				// Override the local resource keys defined in XAML so DynamicResource bindings pick them
+				this.Resources["CardBackgroundBrush"] = controlBg ?? new SolidColorBrush(Color.FromRgb(0x2E, 0x2F, 0x33));
+				this.Resources["CardForegroundBrush"] = controlFg ?? Brushes.White;
+				this.Resources["CardBorderBrush"] = controlBorder ?? new SolidColorBrush(Color.FromRgb(0x44, 0x44, 0x44));
+
+				this.Resources["PrimaryButtonBackgroundBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x5A, 0x9B, 0xD5));
+				this.Resources["PrimaryButtonHoverBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x4B, 0x89, 0xC6));
+				this.Resources["PrimaryButtonForegroundBrush"] = controlFg ?? Brushes.White;
+			}
+			catch { }
+		}
+	}
 }

--- a/source/Views/HowLongToBeatSelect.xaml.cs
+++ b/source/Views/HowLongToBeatSelect.xaml.cs
@@ -310,7 +310,7 @@ namespace HowLongToBeat.Views
             var manualEntry = new HltbDataUser
             {
                 Name = GameContext.Name,
-                Id = null,
+                Id = string.IsNullOrWhiteSpace(PART_ManualHltbId.Text) ? null : PART_ManualHltbId.Text,
                 GameType = resolvedType,
                 GameHltbData = new HltbData
                 {

--- a/source/Views/HowLongToBeatSelect.xaml.cs
+++ b/source/Views/HowLongToBeatSelect.xaml.cs
@@ -28,8 +28,6 @@ namespace HowLongToBeat.Views
         {
             InitializeComponent();
 
-            ApplyThemeResources();
-
             GameContext = game;
             SearchElement.Text = GameContext.Name;
 
@@ -244,28 +242,10 @@ namespace HowLongToBeat.Views
             e.Handled = false;
         }
 
-        private void TabSearch_Click(object sender, RoutedEventArgs e)
+        private void PART_Tabs_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            SwitchToMode(manual: false);
-        }
-
-        private void TabManual_Click(object sender, RoutedEventArgs e)
-        {
-            SwitchToMode(manual: true);
-        }
-
-        private void SwitchToMode(bool manual)
-        {
-            PART_SearchPane.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
-            PART_ManualPane.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
-
-            PART_TabSearch.Style = manual
-                ? (Style)FindResource("TabInactiveStyle")
-                : (Style)FindResource("TabActiveStyle");
-            PART_TabManual.Style = manual
-                ? (Style)FindResource("TabActiveStyle")
-                : (Style)FindResource("TabInactiveStyle");
-
+            if (e.Source != PART_Tabs) return;
+            bool manual = PART_Tabs.SelectedItem == PART_TabManual;
             ButtonSelect.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
             ButtonConfirmManual.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
         }
@@ -327,29 +307,6 @@ namespace HowLongToBeat.Views
             GameHowLongToBeat.Items = new List<HltbDataUser> { manualEntry };
 
             ((Window)Parent).Close();
-        }
-
-        private void ApplyThemeResources()
-        {
-            try
-            {
-                // Try to get common theme brushes from the host via ResourceProvider
-                var normal = ResourceProvider.GetResource("NormalBrush") as Brush;
-                var controlBg = ResourceProvider.GetResource("ControlBackgroundBrush") as Brush ?? normal;
-                var controlFg = ResourceProvider.GetResource("ControlForegroundBrush") as Brush ?? Brushes.White;
-                var controlBorder = ResourceProvider.GetResource("ControlBorderBrush") as Brush ?? Brushes.Gray;
-                var accent = ResourceProvider.GetResource("AccentColorBrush") as Brush ?? normal;
-
-                // Override the local resource keys defined in XAML so DynamicResource bindings pick them
-                this.Resources["CardBackgroundBrush"] = controlBg ?? new SolidColorBrush(Color.FromRgb(0x2E, 0x2F, 0x33));
-                this.Resources["CardForegroundBrush"] = controlFg ?? Brushes.White;
-                this.Resources["CardBorderBrush"] = controlBorder ?? new SolidColorBrush(Color.FromRgb(0x44, 0x44, 0x44));
-
-                this.Resources["PrimaryButtonBackgroundBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x5A, 0x9B, 0xD5));
-                this.Resources["PrimaryButtonHoverBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x4B, 0x89, 0xC6));
-                this.Resources["PrimaryButtonForegroundBrush"] = controlFg ?? Brushes.White;
-            }
-            catch { }
         }
     }
 }

--- a/source/Views/HowLongToBeatSelect.xaml.cs
+++ b/source/Views/HowLongToBeatSelect.xaml.cs
@@ -17,339 +17,339 @@ using Playnite.SDK.Models;
 
 namespace HowLongToBeat.Views
 {
-	public partial class HowLongToBeatSelect : UserControl
-	{
-		private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
+    public partial class HowLongToBeatSelect : UserControl
+    {
+        private static HowLongToBeatDatabase PluginDatabase => HowLongToBeat.PluginDatabase;
 
-		public GameHowLongToBeat GameHowLongToBeat { get; set; }
-		private Game GameContext { get; set; }
+        public GameHowLongToBeat GameHowLongToBeat { get; set; }
+        private Game GameContext { get; set; }
 
-		public HowLongToBeatSelect(Game game, List<HltbDataUser> data)
-		{
-			InitializeComponent();
+        public HowLongToBeatSelect(Game game, List<HltbDataUser> data)
+        {
+            InitializeComponent();
 
-			ApplyThemeResources();
+            ApplyThemeResources();
 
-			GameContext = game;
-			SearchElement.Text = GameContext.Name;
+            GameContext = game;
+            SearchElement.Text = GameContext.Name;
 
-			if (PluginDatabase.PluginSettings.Settings.UseHtltbClassic)
-			{
-				lbSelectable.Tag = DataType.Classic;
-			}
-			if (PluginDatabase.PluginSettings.Settings.UseHtltbAverage)
-			{
-				lbSelectable.Tag = DataType.Average;
-			}
-			if (PluginDatabase.PluginSettings.Settings.UseHtltbMedian)
-			{
-				lbSelectable.Tag = DataType.Median;
-			}
-			if (PluginDatabase.PluginSettings.Settings.UseHtltbRushed)
-			{
-				lbSelectable.Tag = DataType.Rushed;
-			}
-			if (PluginDatabase.PluginSettings.Settings.UseHtltbLeisure)
-			{
-				lbSelectable.Tag = DataType.Leisure;
-			}
+            if (PluginDatabase.PluginSettings.Settings.UseHtltbClassic)
+            {
+                lbSelectable.Tag = DataType.Classic;
+            }
+            if (PluginDatabase.PluginSettings.Settings.UseHtltbAverage)
+            {
+                lbSelectable.Tag = DataType.Average;
+            }
+            if (PluginDatabase.PluginSettings.Settings.UseHtltbMedian)
+            {
+                lbSelectable.Tag = DataType.Median;
+            }
+            if (PluginDatabase.PluginSettings.Settings.UseHtltbRushed)
+            {
+                lbSelectable.Tag = DataType.Rushed;
+            }
+            if (PluginDatabase.PluginSettings.Settings.UseHtltbLeisure)
+            {
+                lbSelectable.Tag = DataType.Leisure;
+            }
 
-			if (data == null)
-			{
-				_ = Task.Run(() =>
-				{
-					Thread.Sleep(300);
-					Application.Current?.Dispatcher?.Invoke(new Action(() =>
-					{
-						SearchData();
-					}));
-				});
-			}
-			else
-			{
-				lbSelectable.ItemsSource = data;
-				lbSelectable.UpdateLayout();
-			}
+            if (data == null)
+            {
+                _ = Task.Run(() =>
+                {
+                    Thread.Sleep(300);
+                    Application.Current?.Dispatcher?.Invoke(new Action(() =>
+                    {
+                        SearchData();
+                    }));
+                });
+            }
+            else
+            {
+                lbSelectable.ItemsSource = data;
+                lbSelectable.UpdateLayout();
+            }
 
-			// Set Binding data
-			DataContext = this;
-		}
+            // Set Binding data
+            DataContext = this;
+        }
 
-		private void ButtonCancel_Click(object sender, RoutedEventArgs e)
-		{
-			((Window)this.Parent).Close();
-		}
+        private void ButtonCancel_Click(object sender, RoutedEventArgs e)
+        {
+            ((Window)this.Parent).Close();
+        }
 
-		/// <summary>
-		/// Valid the selection.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void ButtonSelect_Click(object sender, RoutedEventArgs e)
-		{
-			HltbDataUser Item = (HltbDataUser)lbSelectable.SelectedItem;
+        /// <summary>
+        /// Valid the selection.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ButtonSelect_Click(object sender, RoutedEventArgs e)
+        {
+            HltbDataUser Item = (HltbDataUser)lbSelectable.SelectedItem;
 
-			GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
-			GameHowLongToBeat.Items = new List<HltbDataUser>() { Item };
+            GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
+            GameHowLongToBeat.Items = new List<HltbDataUser>() { Item };
 
-			((Window)this.Parent).Close();
-		}
+            ((Window)this.Parent).Close();
+        }
 
-		/// <summary>
-		/// Deblock validation button after a selection.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void LbSelectable_SelectionChanged(object sender, SelectionChangedEventArgs e)
-		{
-			ButtonSelect.IsEnabled = true;
-		}
+        /// <summary>
+        /// Deblock validation button after a selection.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void LbSelectable_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ButtonSelect.IsEnabled = true;
+        }
 
-		/// <summary>
-		/// Search element by name.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void ButtonSearch_Click(object sender, RoutedEventArgs e)
-		{
-			SearchData();
-		}
+        /// <summary>
+        /// Search element by name.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ButtonSearch_Click(object sender, RoutedEventArgs e)
+        {
+            SearchData();
+        }
 
-		private void SearchData()
-		{
-			lbSelectable.ItemsSource = null;
+        private void SearchData()
+        {
+            lbSelectable.ItemsSource = null;
 
-			string gameSearch = SearchElement.Text;
-			string gamePlatform = (PART_SelectPlatform.SelectedValue == null)
-				  ? string.Empty
-				  : ((HltbPlatform)PART_SelectPlatform.SelectedValue).GetDescription();
+            string gameSearch = SearchElement.Text;
+            string gamePlatform = (PART_SelectPlatform.SelectedValue == null)
+                  ? string.Empty
+                  : ((HltbPlatform)PART_SelectPlatform.SelectedValue).GetDescription();
 
-			bool isVndb = (bool)PART_Vndb.IsChecked;
+            bool isVndb = (bool)PART_Vndb.IsChecked;
 
-			GlobalProgressOptions globalProgressOptions = new GlobalProgressOptions($"{ResourceProvider.GetString("LOCDownloadingLabel")}")
-			{
-				Cancelable = false,
-				IsIndeterminate = true
-			};
+            GlobalProgressOptions globalProgressOptions = new GlobalProgressOptions($"{ResourceProvider.GetString("LOCDownloadingLabel")}")
+            {
+                Cancelable = false,
+                IsIndeterminate = true
+            };
 
-			_ = API.Instance.Dialogs.ActivateGlobalProgress(async (activateGlobalProgress) =>
-			{
-				List<HltbDataUser> dataSearch = new List<HltbDataUser>();
-				try
-				{
-					if (isVndb)
-					{
-						var vndbResults = await VndbApi.SearchByNameAsync(gameSearch);
-						dataSearch = vndbResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
-					}
-					else
-					{
-						var hlResults = await PluginDatabase.HowLongToBeatApi.SearchTwoMethod(gameSearch, gamePlatform, includeExtendedTimes: true);
-						dataSearch = hlResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
-					}
-				}
-				catch (Exception ex)
-				{
-					Common.LogError(ex, false, true, PluginDatabase.PluginName);
-				}
+            _ = API.Instance.Dialogs.ActivateGlobalProgress(async (activateGlobalProgress) =>
+            {
+                List<HltbDataUser> dataSearch = new List<HltbDataUser>();
+                try
+                {
+                    if (isVndb)
+                    {
+                        var vndbResults = await VndbApi.SearchByNameAsync(gameSearch);
+                        dataSearch = vndbResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
+                    }
+                    else
+                    {
+                        var hlResults = await PluginDatabase.HowLongToBeatApi.SearchTwoMethod(gameSearch, gamePlatform, includeExtendedTimes: true);
+                        dataSearch = hlResults?.Select(x => x.Data).ToList() ?? new List<HltbDataUser>();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Common.LogError(ex, false, true, PluginDatabase.PluginName);
+                }
 
-				Common.LogDebug(true, $"dataSearch: {Serialization.ToJson(dataSearch)}");
-				Application.Current.Dispatcher?.Invoke(new Action(() =>
-				{
-					lbSelectable.ItemsSource = dataSearch;
-					lbSelectable.UpdateLayout();
-				}));
-			}, globalProgressOptions);
-		}
+                Common.LogDebug(true, $"dataSearch: {Serialization.ToJson(dataSearch)}");
+                Application.Current.Dispatcher?.Invoke(new Action(() =>
+                {
+                    lbSelectable.ItemsSource = dataSearch;
+                    lbSelectable.UpdateLayout();
+                }));
+            }, globalProgressOptions);
+        }
 
-		/// <summary>
-		/// Show or not the ToolTip.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void TextBlock_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
-		{
-			var textBlock = sender as TextBlock;
-			if (textBlock == null) return;
+        /// <summary>
+        /// Show or not the ToolTip.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBlock_MouseEnter(object sender, System.Windows.Input.MouseEventArgs e)
+        {
+            var textBlock = sender as TextBlock;
+            if (textBlock == null) return;
 
-			var toolTip = textBlock.ToolTip as ToolTip;
-			if (toolTip == null) return;
+            var toolTip = textBlock.ToolTip as ToolTip;
+            if (toolTip == null) return;
 
-			try
-			{
-				var text = textBlock.Text ?? string.Empty;
-				if (string.IsNullOrEmpty(text))
-				{
-					toolTip.Visibility = Visibility.Hidden;
-					return;
-				}
+            try
+            {
+                var text = textBlock.Text ?? string.Empty;
+                if (string.IsNullOrEmpty(text))
+                {
+                    toolTip.Visibility = Visibility.Hidden;
+                    return;
+                }
 
-				var typeface = new Typeface(
-					textBlock.FontFamily,
-					textBlock.FontStyle,
-					textBlock.FontWeight,
-					textBlock.FontStretch);
+                var typeface = new Typeface(
+                    textBlock.FontFamily,
+                    textBlock.FontStyle,
+                    textBlock.FontWeight,
+                    textBlock.FontStretch);
 
-				// Use the FormattedText overload with PixelsPerDip to avoid obsolete warning
-				double pixelsPerDip = 1.0;
-				try
-				{
-					pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
-				}
-				catch { }
+                // Use the FormattedText overload with PixelsPerDip to avoid obsolete warning
+                double pixelsPerDip = 1.0;
+                try
+                {
+                    pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+                }
+                catch { }
 
-				var formattedText = new FormattedText(
-					text,
-					System.Threading.Thread.CurrentThread.CurrentCulture,
-					textBlock.FlowDirection,
-					typeface,
-					textBlock.FontSize,
-					textBlock.Foreground,
-					pixelsPerDip);
+                var formattedText = new FormattedText(
+                    text,
+                    System.Threading.Thread.CurrentThread.CurrentCulture,
+                    textBlock.FlowDirection,
+                    typeface,
+                    textBlock.FontSize,
+                    textBlock.Foreground,
+                    pixelsPerDip);
 
-				// Compare measured width with actual available width. If larger, show tooltip.
-				toolTip.Visibility = formattedText.Width > (textBlock.ActualWidth - 1.0)
-					? Visibility.Visible
-					: Visibility.Hidden;
-			}
-			catch
-			{
-				// On any error, hide tooltip rather than crash
-				try { toolTip.Visibility = Visibility.Hidden; } catch { }
-			}
-		}
+                // Compare measured width with actual available width. If larger, show tooltip.
+                toolTip.Visibility = formattedText.Width > (textBlock.ActualWidth - 1.0)
+                    ? Visibility.Visible
+                    : Visibility.Hidden;
+            }
+            catch
+            {
+                // On any error, hide tooltip rather than crash
+                try { toolTip.Visibility = Visibility.Hidden; } catch { }
+            }
+        }
 
-		/// <summary>
-		/// Valid search by enter key.
-		/// </summary>
-		/// <param name="sender"></param>
-		/// <param name="e"></param>
-		private void SearchElement_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
-		{
-			if (e.Key == System.Windows.Input.Key.Enter)
-			{
-				ButtonSearch_Click(null, null);
-			}
-		}
+        /// <summary>
+        /// Valid search by enter key.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SearchElement_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                ButtonSearch_Click(null, null);
+            }
+        }
 
-		private void ListBoxItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
-		{
-			var lbi = sender as ListBoxItem;
-			if (lbi == null) return;
+        private void ListBoxItem_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            var lbi = sender as ListBoxItem;
+            if (lbi == null) return;
 
-			if (!lbi.IsSelected)
-			{
-				lbi.IsSelected = true;
-			}
-			e.Handled = false;
-		}
+            if (!lbi.IsSelected)
+            {
+                lbi.IsSelected = true;
+            }
+            e.Handled = false;
+        }
 
-		private void TabSearch_Click(object sender, RoutedEventArgs e)
-		{
-			SwitchToMode(manual: false);
-		}
+        private void TabSearch_Click(object sender, RoutedEventArgs e)
+        {
+            SwitchToMode(manual: false);
+        }
 
-		private void TabManual_Click(object sender, RoutedEventArgs e)
-		{
-			SwitchToMode(manual: true);
-		}
+        private void TabManual_Click(object sender, RoutedEventArgs e)
+        {
+            SwitchToMode(manual: true);
+        }
 
-		private void SwitchToMode(bool manual)
-		{
-			PART_SearchPane.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
-			PART_ManualPane.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
+        private void SwitchToMode(bool manual)
+        {
+            PART_SearchPane.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
+            PART_ManualPane.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
 
-			PART_TabSearch.Style = manual
-				? (Style)FindResource("TabInactiveStyle")
-				: (Style)FindResource("TabActiveStyle");
-			PART_TabManual.Style = manual
-				? (Style)FindResource("TabActiveStyle")
-				: (Style)FindResource("TabInactiveStyle");
+            PART_TabSearch.Style = manual
+                ? (Style)FindResource("TabInactiveStyle")
+                : (Style)FindResource("TabActiveStyle");
+            PART_TabManual.Style = manual
+                ? (Style)FindResource("TabActiveStyle")
+                : (Style)FindResource("TabInactiveStyle");
 
-			ButtonSelect.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
-			ButtonConfirmManual.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
-		}
+            ButtonSelect.Visibility = manual ? Visibility.Collapsed : Visibility.Visible;
+            ButtonConfirmManual.Visibility = manual ? Visibility.Visible : Visibility.Collapsed;
+        }
 
-		private void ButtonOpenOnWebsite_Click(object sender, RoutedEventArgs e)
-		{
-			try
-			{
-				var query = Uri.EscapeDataString(GameContext.Name ?? string.Empty);
-				var url = "https://howlongtobeat.com/?q=" + query;
-				var psi = new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true };
-				System.Diagnostics.Process.Start(psi);
-			}
-			catch (Exception ex)
-			{
-				Common.LogError(ex, false, true, PluginDatabase.PluginName);
-			}
-		}
+        private void ButtonOpenOnWebsite_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var query = Uri.EscapeDataString(GameContext.Name ?? string.Empty);
+                var url = "https://howlongtobeat.com/?q=" + query;
+                var psi = new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true };
+                System.Diagnostics.Process.Start(psi);
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginDatabase.PluginName);
+            }
+        }
 
-		private static long ParseHoursMinutesToSeconds(string hours, string minutes)
-		{
-			double.TryParse(hours?.Trim(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var h);
-			double.TryParse(minutes?.Trim(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var m);
-			var total = (long)(h * 3600 + m * 60);
-			return total < 0 ? 0 : total;
-		}
+        private static long ParseHoursMinutesToSeconds(string hours, string minutes)
+        {
+            double.TryParse(hours?.Trim(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var h);
+            double.TryParse(minutes?.Trim(), System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var m);
+            var total = (long)(h * 3600 + m * 60);
+            return total < 0 ? 0 : total;
+        }
 
-		private void ButtonAddManual_Click(object sender, RoutedEventArgs e)
-		{
-			var mainStory = ParseHoursMinutesToSeconds(PART_ManualMainStoryH.Text, PART_ManualMainStoryM.Text);
-			var mainExtra = ParseHoursMinutesToSeconds(PART_ManualMainExtraH.Text, PART_ManualMainExtraM.Text);
-			var completionist = ParseHoursMinutesToSeconds(PART_ManualCompletionistH.Text, PART_ManualCompletionistM.Text);
-			var solo = ParseHoursMinutesToSeconds(PART_ManualSoloH.Text, PART_ManualSoloM.Text);
-			var coOp = ParseHoursMinutesToSeconds(PART_ManualCoOpH.Text, PART_ManualCoOpM.Text);
+        private void ButtonAddManual_Click(object sender, RoutedEventArgs e)
+        {
+            var mainStory = ParseHoursMinutesToSeconds(PART_ManualMainStoryH.Text, PART_ManualMainStoryM.Text);
+            var mainExtra = ParseHoursMinutesToSeconds(PART_ManualMainExtraH.Text, PART_ManualMainExtraM.Text);
+            var completionist = ParseHoursMinutesToSeconds(PART_ManualCompletionistH.Text, PART_ManualCompletionistM.Text);
+            var solo = ParseHoursMinutesToSeconds(PART_ManualSoloH.Text, PART_ManualSoloM.Text);
+            var coOp = ParseHoursMinutesToSeconds(PART_ManualCoOpH.Text, PART_ManualCoOpM.Text);
 
-			var hasMulti = solo > 0 || coOp > 0;
+            var hasMulti = solo > 0 || coOp > 0;
 
-			var resolvedType = hasMulti && mainStory == 0 && mainExtra == 0 && completionist == 0
-				? GameType.Multi
-				: GameType.Game;
+            var resolvedType = hasMulti && mainStory == 0 && mainExtra == 0 && completionist == 0
+                ? GameType.Multi
+                : GameType.Game;
 
-			var manualEntry = new HltbDataUser
-			{
-				Name = GameContext.Name,
-				Id = null,
-				GameType = resolvedType,
-				GameHltbData = new HltbData
-				{
-					GameType = resolvedType,
-					MainStoryClassic = mainStory,
-					MainExtraClassic = mainExtra,
-					CompletionistClassic = completionist,
-					SoloClassic = solo,
-					CoOpClassic = coOp
-				}
-			};
+            var manualEntry = new HltbDataUser
+            {
+                Name = GameContext.Name,
+                Id = null,
+                GameType = resolvedType,
+                GameHltbData = new HltbData
+                {
+                    GameType = resolvedType,
+                    MainStoryClassic = mainStory,
+                    MainExtraClassic = mainExtra,
+                    CompletionistClassic = completionist,
+                    SoloClassic = solo,
+                    CoOpClassic = coOp
+                }
+            };
 
-			GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
-			GameHowLongToBeat.Items = new List<HltbDataUser> { manualEntry };
+            GameHowLongToBeat = HowLongToBeat.PluginDatabase.GetDefault(GameContext);
+            GameHowLongToBeat.Items = new List<HltbDataUser> { manualEntry };
 
-			((Window)Parent).Close();
-		}
+            ((Window)Parent).Close();
+        }
 
-		private void ApplyThemeResources()
-		{
-			try
-			{
-				// Try to get common theme brushes from the host via ResourceProvider
-				var normal = ResourceProvider.GetResource("NormalBrush") as Brush;
-				var controlBg = ResourceProvider.GetResource("ControlBackgroundBrush") as Brush ?? normal;
-				var controlFg = ResourceProvider.GetResource("ControlForegroundBrush") as Brush ?? Brushes.White;
-				var controlBorder = ResourceProvider.GetResource("ControlBorderBrush") as Brush ?? Brushes.Gray;
-				var accent = ResourceProvider.GetResource("AccentColorBrush") as Brush ?? normal;
+        private void ApplyThemeResources()
+        {
+            try
+            {
+                // Try to get common theme brushes from the host via ResourceProvider
+                var normal = ResourceProvider.GetResource("NormalBrush") as Brush;
+                var controlBg = ResourceProvider.GetResource("ControlBackgroundBrush") as Brush ?? normal;
+                var controlFg = ResourceProvider.GetResource("ControlForegroundBrush") as Brush ?? Brushes.White;
+                var controlBorder = ResourceProvider.GetResource("ControlBorderBrush") as Brush ?? Brushes.Gray;
+                var accent = ResourceProvider.GetResource("AccentColorBrush") as Brush ?? normal;
 
-				// Override the local resource keys defined in XAML so DynamicResource bindings pick them
-				this.Resources["CardBackgroundBrush"] = controlBg ?? new SolidColorBrush(Color.FromRgb(0x2E, 0x2F, 0x33));
-				this.Resources["CardForegroundBrush"] = controlFg ?? Brushes.White;
-				this.Resources["CardBorderBrush"] = controlBorder ?? new SolidColorBrush(Color.FromRgb(0x44, 0x44, 0x44));
+                // Override the local resource keys defined in XAML so DynamicResource bindings pick them
+                this.Resources["CardBackgroundBrush"] = controlBg ?? new SolidColorBrush(Color.FromRgb(0x2E, 0x2F, 0x33));
+                this.Resources["CardForegroundBrush"] = controlFg ?? Brushes.White;
+                this.Resources["CardBorderBrush"] = controlBorder ?? new SolidColorBrush(Color.FromRgb(0x44, 0x44, 0x44));
 
-				this.Resources["PrimaryButtonBackgroundBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x5A, 0x9B, 0xD5));
-				this.Resources["PrimaryButtonHoverBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x4B, 0x89, 0xC6));
-				this.Resources["PrimaryButtonForegroundBrush"] = controlFg ?? Brushes.White;
-			}
-			catch { }
-		}
-	}
+                this.Resources["PrimaryButtonBackgroundBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x5A, 0x9B, 0xD5));
+                this.Resources["PrimaryButtonHoverBrush"] = accent ?? new SolidColorBrush(Color.FromRgb(0x4B, 0x89, 0xC6));
+                this.Resources["PrimaryButtonForegroundBrush"] = controlFg ?? Brushes.White;
+            }
+            catch { }
+        }
+    }
 }

--- a/source/Views/HowLongToBeatSelect.xaml.cs
+++ b/source/Views/HowLongToBeatSelect.xaml.cs
@@ -310,7 +310,7 @@ namespace HowLongToBeat.Views
             var manualEntry = new HltbDataUser
             {
                 Name = GameContext.Name,
-                Id = string.IsNullOrWhiteSpace(PART_ManualHltbId.Text) ? null : PART_ManualHltbId.Text,
+                Id = PART_ManualHltbId.Text.Trim(),
                 GameType = resolvedType,
                 GameHltbData = new HltbData
                 {

--- a/source/Views/HowLongToBeatView.xaml
+++ b/source/Views/HowLongToBeatView.xaml
@@ -14,6 +14,7 @@
 
     <UserControl.Resources>
         <converters:PlayTimeToStringConverter x:Key="PlayTimeToStringConverter"/>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
 
         <SolidColorBrush x:Key="DataColorClassicBrush"
                          Color="DarkCyan"/>
@@ -447,6 +448,7 @@
                                 Click="ButtonRefresh_Click"
                                 Content="&#xefd1;"
                                 FontFamily="{DynamicResource FontIcoFont}"
+                                Visibility="{Binding HasHltbId, Converter={StaticResource BooleanToVisibilityConverter}}"
                                 Tag="{Binding GameContext.Id}"/>
                         <Button Style="{StaticResource IconButtonStyle}"
                                 Margin="0,10,0,0"

--- a/source/Views/HowLongToBeatView.xaml.cs
+++ b/source/Views/HowLongToBeatView.xaml.cs
@@ -330,11 +330,14 @@ namespace HowLongToBeat.Views
 
             if (gameData == null || gameData.Name.IsNullOrEmpty())
             {
+                ((HowLongToBeatViewData)DataContext).HasHltbId = false;
                 return;
             }
 
             if (gameData != null)
             {
+                ((HowLongToBeatViewData)DataContext).HasHltbId = !gameData.Id.IsNullOrEmpty();
+
                 ((HowLongToBeatViewData)DataContext).CoverImage = gameData.UrlImg;
 
                 if (!PluginDatabase.PluginSettings.Settings.ShowHltbImg)
@@ -883,5 +886,8 @@ namespace HowLongToBeat.Views
 
         private string _completionistHoursFormat = string.Empty;
         public string CompletionistHoursFormat { get => _completionistHoursFormat; set => SetValue(ref _completionistHoursFormat, value); }
+
+        private bool _hasHltbId = false;
+        public bool HasHltbId { get => _hasHltbId; set => SetValue(ref _hasHltbId, value); }
     }
 }


### PR DESCRIPTION
Changes:
* Added manual data entry
* Took some changes from azuravian's PR (https://github.com/Lacro59/playnite-howlongtobeat-plugin/pull/334) to make search work again
* Removed custom styles from search

More on the new functionality:

Added a "tab" to manually add HLTB data. This allows to continue using the extension even if the API parsing is broken due to frequent HLTB changes.

An additional "Search on HowLongToBeat" button opens up  HLTB website search query in browser for easier data access.

<img width="730" height="714" alt="image" src="https://github.com/user-attachments/assets/f1f0f00f-6116-4a76-aa64-468feb4cf284" />
<img width="720" height="461" alt="image" src="https://github.com/user-attachments/assets/c62b26e1-b851-46e7-b8db-7bce2e000472" />

The data can be saved without or with an `Id`. If the data has not `Id`, then the refresh button is hidden in the progress dialog for the game.

<img width="920" height="441" alt="image" src="https://github.com/user-attachments/assets/9389fc55-dbfb-4e15-92f1-95c069d49fde" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed Search and Manual modes with a manual-entry form for custom playtimes and a confirm action.
  * "Open website" button to look up games externally.

* **Improvements**
  * Simplified and reorganized search/results layout and item visuals.
  * Refresh button now appears only when an external ID is present.
  * Tab switching updates available action buttons.

* **Bug Fixes**
  * Prevents saving when a game lacks an external ID and shows an error notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->