### PR TITLE
Exclude games from playtime sync

### DIFF
--- a/source/HowLongToBeat.cs
+++ b/source/HowLongToBeat.cs
@@ -256,7 +256,8 @@ namespace HowLongToBeat
             }
 
             // AutoSetCurrentPlayTime
-            if (PluginDatabase.PluginSettings.AutoSetCurrentPlayTime)
+            if (PluginDatabase.PluginSettings.AutoSetCurrentPlayTime
+                && !PluginDatabase.IsExcludedFromAutoPlaytimeSync(args.Game))
             {
                 try
                 {

--- a/source/Localization/LocSource.xaml
+++ b/source/Localization/LocSource.xaml
@@ -201,6 +201,9 @@ This is separate from the Replays list on your profile.</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatSetCurrentTimeManual">Set your current playtime</sys:String>
     <sys:String x:Key="LOCHowLongToBeatSetCurrentTimeManualAll">Set your current playtime for all games</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatExcludeAutoPlaytimeSyncTag">Excluded from auto playtime sync</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatExcludeAutoPlaytimeSyncForGame">Exclude game from auto playtime sync</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatEnableAutoPlaytimeSyncForGame">Enable auto playtime sync for game</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatSetCurrentCompletedTimeManualOn">Set your current completed playtime on</sys:String>
     <sys:String x:Key="LOCHowLongToBeatSetCurrentMultiTimeManualOn">Set your current muli playtime on</sys:String>

--- a/source/Localization/en_US.xaml
+++ b/source/Localization/en_US.xaml
@@ -201,6 +201,9 @@ This is separate from the Replays list on your profile.</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatSetCurrentTimeManual">Set your current playtime</sys:String>
     <sys:String x:Key="LOCHowLongToBeatSetCurrentTimeManualAll">Set your current playtime for all games</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatExcludeAutoPlaytimeSyncTag">Excluded from auto playtime sync</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatExcludeAutoPlaytimeSyncForGame">Exclude game from auto playtime sync</sys:String>
+    <sys:String x:Key="LOCHowLongToBeatEnableAutoPlaytimeSyncForGame">Enable auto playtime sync for game</sys:String>
 
     <sys:String x:Key="LOCHowLongToBeatSetCurrentCompletedTimeManualOn">Set your current completed playtime on</sys:String>
     <sys:String x:Key="LOCHowLongToBeatSetCurrentMultiTimeManualOn">Set your current muli playtime on</sys:String>

--- a/source/Services/HowLongToBeatDatabase.cs
+++ b/source/Services/HowLongToBeatDatabase.cs
@@ -624,6 +624,65 @@ namespace HowLongToBeat.Services
 
         #endregion
 
+        #region Auto sync tag
+
+        private Guid? ExcludeAutoPlaytimeSyncTagId => API.Instance.Database.Tags?
+            .FirstOrDefault(x => x.Name == $"{TagBefore} {ResourceProvider.GetString("LOCHowLongToBeatExcludeAutoPlaytimeSyncTag")}")?.Id;
+
+        public bool IsExcludedFromAutoPlaytimeSync(Game game)
+        {
+            try
+            {
+                return ExcludeAutoPlaytimeSyncTagId is Guid tagId && game.TagIds?.Contains(tagId) == true;
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginName);
+                return false;
+            }
+        }
+
+        public void SetExcludedFromAutoPlaytimeSync(IEnumerable<Game> games, bool excluded)
+        {
+            try
+            {
+                Guid? tagId = ExcludeAutoPlaytimeSyncTagId;
+                if (excluded && tagId == null)
+                {
+                    tagId = CheckTagExist(ResourceProvider.GetString("LOCHowLongToBeatExcludeAutoPlaytimeSyncTag"));
+                }
+
+                if (tagId == null)
+                {
+                    return;
+                }
+
+                foreach (Game game in games)
+                {
+                    game.TagIds = game.TagIds ?? new List<Guid>();
+                    if (excluded)
+                    {
+                        if (game.TagIds.Contains(tagId.Value))
+                        {
+                            continue;
+                        }
+                        game.TagIds.Add(tagId.Value);
+                    }
+                    else if (!game.TagIds.Remove(tagId.Value))
+                    {
+                        continue;
+                    }
+                    API.Instance.Database.Games.Update(game);
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex, false, true, PluginName);
+            }
+        }
+
+        #endregion
+
         #region User data
         public TitleList GetUserHltbData(string hltbId)
         {

--- a/source/Services/HowLongToBeatMenus.cs
+++ b/source/Services/HowLongToBeatMenus.cs
@@ -56,7 +56,17 @@ namespace HowLongToBeat.Services
 
             if (gameHowLongToBeat?.HasData == true)
             {
+                bool allExcludedFromAutoSync = args.Games.All(Database.IsExcludedFromAutoPlaytimeSync);
                 HltbDataUser gameData = gameHowLongToBeat.Items?.FirstOrDefault();
+
+                gameMenuItems.Add(new GameMenuItem
+                {
+                    MenuSection = ResourceProvider.GetString("LOCHowLongToBeat"),
+                    Description = allExcludedFromAutoSync
+                        ? ResourceProvider.GetString("LOCHowLongToBeatEnableAutoPlaytimeSyncForGame")
+                        : ResourceProvider.GetString("LOCHowLongToBeatExcludeAutoPlaytimeSyncForGame"),
+                    Action = (mainMenuItem) => Database.SetExcludedFromAutoPlaytimeSync(args.Games, !allExcludedFromAutoSync)
+                });
 
                 gameMenuItems.Add(new GameMenuItem
                 {

--- a/source/Services/HowLongToBeatMenus.cs
+++ b/source/Services/HowLongToBeatMenus.cs
@@ -31,6 +31,7 @@ namespace HowLongToBeat.Services
 
             Game gameMenu = args.Games.First();
             List<Guid> ids = args.Games.Select(x => x.Id).ToList();
+            bool allExcludedFromAutoSync = args.Games.All(Database.IsExcludedFromAutoPlaytimeSync);
             GameHowLongToBeat gameHowLongToBeat = Database.Get(gameMenu, true);
 
             List<GameMenuItem> gameMenuItems = new List<GameMenuItem>
@@ -51,22 +52,21 @@ namespace HowLongToBeat.Services
                             API.Instance.Dialogs.ShowErrorMessage(ResourceProvider.GetString("LOCDatabaseErroTitle"), Database.PluginName);
                         }
                     }
-                }
-            };
-
-            if (gameHowLongToBeat?.HasData == true)
-            {
-                bool allExcludedFromAutoSync = args.Games.All(Database.IsExcludedFromAutoPlaytimeSync);
-                HltbDataUser gameData = gameHowLongToBeat.Items?.FirstOrDefault();
-
-                gameMenuItems.Add(new GameMenuItem
+                },
+                new GameMenuItem
                 {
                     MenuSection = ResourceProvider.GetString("LOCHowLongToBeat"),
                     Description = allExcludedFromAutoSync
                         ? ResourceProvider.GetString("LOCHowLongToBeatEnableAutoPlaytimeSyncForGame")
                         : ResourceProvider.GetString("LOCHowLongToBeatExcludeAutoPlaytimeSyncForGame"),
                     Action = (mainMenuItem) => Database.SetExcludedFromAutoPlaytimeSync(args.Games, !allExcludedFromAutoSync)
-                });
+                }
+
+            };
+
+            if (gameHowLongToBeat?.HasData == true)
+            {
+                HltbDataUser gameData = gameHowLongToBeat.Items?.FirstOrDefault();
 
                 gameMenuItems.Add(new GameMenuItem
                 {


### PR DESCRIPTION
Hello,
This PR adds basic support to exclude a game for playtime sync (through a specific tag), and a menu option on game selection to exclude a game from the sync.

This closes #374
Only English localization is included. You have edit permission on the PR if you have any input about the tag or dialog names

I have tested this for a few days without any negative impact. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to exclude selected games from automatic playtime synchronization.
  - Supports applying or removing the exclusion for multiple games at once.
  - Menu labels reflect the selected games’ current exclusion status, including games without stored playtime data.

- **Bug Fixes**
  - Excluded games no longer have their playtime automatically synchronized when gameplay ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->