### PR TITLE
Fix HLTB site search endpoints

### DIFF
--- a/source/Services/HowLongToBeatApi.cs
+++ b/source/Services/HowLongToBeatApi.cs
@@ -1583,7 +1583,7 @@ namespace HowLongToBeat.Services
                 {
                     new HttpHeader { Key = "Referer", Value = UrlBase }
                 };
-                string url = $"{UrlBase}{apiEndpoint}/init?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+                string url = $"{UrlBase}{apiEndpoint}{(apiEndpoint == "/api/search" ? "/site/init" : "/init")}?t={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
                 string response = null;
                 try
                 {
@@ -2014,7 +2014,7 @@ namespace HowLongToBeat.Services
                 }
 
                 Dictionary<string, string> headerParts = authResolution.Item1;
-                string searchUrl = authResolution.Item2;
+                string searchUrl = authResolution.Item2 == "/api/search" ? $"{authResolution.Item2}/site" : authResolution.Item2;
                 Common.LogDebug(true, $"ApiSearch: POST endpoint='{searchUrl}' game='{name}' platform='{platform}'");
                 string token = headerParts.TryGetValue("Token", out string tokenValue) ? tokenValue : null;
                 string hpKey = headerParts.TryGetValue("Hpkey", out string hpKeyValue) ? hpKeyValue : null;


### PR DESCRIPTION
Fixes #378

HowLongToBeat's current website search flow has moved its site-search routes:
- GET `/api/search/init` → `/api/search/site/init`
- POST `/api/search` → `/api/search/site`

The existing endpoint discovery still resolves `/api/search`, so this change only adjusts the init and POST paths when that endpoint is used, preserving existing behaviour for other/fallback endpoints.

Tested locally against the current HLTB site:
- Reproduced the HTTP 404 / blank search issue on unmodified master
- 'Elden Ring' returns the expected results and completion data
- 'KINGDOM HEARTS Birth by Sleep FINAL MIX' returns the expected results and completion data
- 'Yakuza 0' returns the expected results and completion data
- Invalid titles return no results cleanly
- Debug build succeeds with 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HowLongToBeat search compatibility by using the correct initialization and search request paths.
  * Existing search behavior for other endpoints remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->