### PR TITLE
fix(sort): sort remaining time column numerically

### DIFF
--- a/source/Views/HowLongToBeatUserView.xaml
+++ b/source/Views/HowLongToBeatUserView.xaml
@@ -474,7 +474,8 @@
                                                                                            RefIndex="12"/>
                                             </GridViewColumn>
                                             <GridViewColumn Width="130"
-                                                            DisplayMemberBinding="{Binding RemainingTimeFormat}">
+                                                            DisplayMemberBinding="{Binding RemainingTimeFormat}"
+                                                            controlsShared:ListViewColumnOptions.SortMemberPath="RemainingTime">
                                                 <GridViewColumnHeader Tag="RemainingTime">
                                                 <StackPanel Orientation="Horizontal">
                                                     <TextBlock Text="&#xed0d;"


### PR DESCRIPTION
The Remaining Time column was sorting by the formatted string, instead of the raw time value. This change makes its sorting consistent with the "Time Played" and "Time to beat" columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sorting by remaining time now uses the underlying numeric value, providing more accurate ordering than sorting the displayed formatted text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->